### PR TITLE
[Feat] 초기 프로젝트 구조 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+out/
+lib/
+.idea/
+*.class
+*.iml
+config/config.properties
+src/main/resources/config.properties

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Gitalk 컴파일 스크립트
+
+SRC_DIR="src/main/java"
+RESOURCES_DIR="src/main/resources"
+OUT_DIR="out"
+LIB_DIR="lib"
+
+# lib 폴더에 JAR이 있는지 확인
+if [ -z "$(ls -A $LIB_DIR 2>/dev/null)" ]; then
+    echo "오류: $LIB_DIR/ 폴더에 JAR 파일이 없습니다."
+    echo "아래 파일을 다운로드해서 lib/ 에 넣어주세요:"
+    echo "  - mysql-connector-j-8.x.x.jar (https://dev.mysql.com/downloads/connector/j/)"
+    echo "  - gson-2.x.x.jar              (https://github.com/google/gson/releases)"
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+SRC_FILES=$(find "$SRC_DIR" -name "*.java")
+
+javac --release 21 -cp "$LIB_DIR/*" -d "$OUT_DIR" $SRC_FILES
+
+if [ $? -eq 0 ]; then
+    cp -r "$RESOURCES_DIR/." "$OUT_DIR/"
+    echo "컴파일 성공"
+else
+    echo "컴파일 실패"
+    exit 1
+fi

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Gitalk 실행 스크립트
+
+OUT_DIR="out"
+LIB_DIR="lib"
+
+java -cp "$OUT_DIR:$LIB_DIR/*" com.gitalk.GitalkApplication

--- a/src/main/java/com/gitalk/GitalkApplication.java
+++ b/src/main/java/com/gitalk/GitalkApplication.java
@@ -1,0 +1,33 @@
+package com.gitalk;
+
+import com.gitalk.chatbot.ChatBot;
+
+import java.util.Scanner;
+
+public class GitalkApplication {
+
+    public static void main(String[] args) {
+        System.out.println("""
+                ╔══════════════════════════════════════════╗
+                ║   Gitalk - 개발자를 위한 CLI 챗봇             ║
+                ╚══════════════════════════════════════════╝
+                """);
+
+        ChatBot chatBot = new ChatBot();
+        chatBot.printHelp();
+
+        Scanner scanner = new Scanner(System.in);
+        while (true) {
+            System.out.print("> ");
+            String input = scanner.nextLine().trim();
+
+            if (input.isEmpty()) continue;
+            if ("exit".equalsIgnoreCase(input)) {
+                System.out.println("Gitalk을 종료합니다.");
+                System.exit(0);
+            }
+
+            chatBot.handleCommand(input);
+        }
+    }
+}

--- a/src/main/java/com/gitalk/api/GithubTrendingClient.java
+++ b/src/main/java/com/gitalk/api/GithubTrendingClient.java
@@ -1,0 +1,86 @@
+package com.gitalk.api;
+
+import com.gitalk.model.TrendingRepo;
+import com.gitalk.util.AppConfig;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GithubTrendingClient {
+
+    private static final String SEARCH_API = "https://api.github.com/search/repositories";
+    private final HttpClient httpClient;
+    private final String token;
+
+    public GithubTrendingClient() {
+        this.token = AppConfig.get("github.token");
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    /**
+     * 최근 7일간 가장 많은 스타를 받은 레포지토리 목록을 가져옵니다.
+     * @param filter null이면 전체, "java" 같은 언어명, "topic:ai" 같은 주제 지정 가능
+     */
+    public List<TrendingRepo> fetchTrending(int count, String filter) throws Exception {
+        String since = LocalDate.now().minusDays(7).toString();
+        StringBuilder q = new StringBuilder("created:>").append(since);
+
+        if (filter != null && !filter.isBlank()) {
+            if (filter.startsWith("topic:")) {
+                q.append(" ").append(filter);
+            } else {
+                q.append(" language:").append(filter);
+            }
+        }
+
+        String query = URLEncoder.encode(q.toString(), StandardCharsets.UTF_8);
+        String url = SEARCH_API + "?q=" + query + "&sort=stars&order=desc&per_page=" + count;
+
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .timeout(Duration.ofSeconds(15))
+                .GET();
+
+        if (token != null && !token.isBlank() && !token.startsWith("YOUR_")) {
+            builder.header("Authorization", "Bearer " + token);
+        }
+
+        HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new RuntimeException("GitHub API 오류: " + response.statusCode());
+        }
+
+        JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
+        JsonArray items = json.getAsJsonArray("items");
+
+        List<TrendingRepo> repos = new ArrayList<>();
+        for (JsonElement element : items) {
+            JsonObject repo = element.getAsJsonObject();
+            String fullName = repo.get("full_name").getAsString();
+            String description = repo.get("description").isJsonNull() ? null : repo.get("description").getAsString();
+            int stars = repo.get("stargazers_count").getAsInt();
+            String language = repo.get("language").isJsonNull() ? null : repo.get("language").getAsString();
+            String htmlUrl = repo.get("html_url").getAsString();
+
+            repos.add(new TrendingRepo(fullName, description, stars, language, htmlUrl));
+        }
+        return repos;
+    }
+}

--- a/src/main/java/com/gitalk/api/GithubWebhookServer.java
+++ b/src/main/java/com/gitalk/api/GithubWebhookServer.java
@@ -1,0 +1,122 @@
+package com.gitalk.api;
+
+import com.gitalk.model.WebhookEvent;
+import com.gitalk.util.AppConfig;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+
+public class GithubWebhookServer {
+
+    private final int port;
+    private HttpServer server;
+    private final List<WebhookEvent> receivedEvents = Collections.synchronizedList(new ArrayList<>());
+    private Consumer<WebhookEvent> eventListener;
+
+    public GithubWebhookServer() {
+        this.port = Integer.parseInt(AppConfig.get("webhook.server.port"));
+    }
+
+    public void start() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/webhook", this::handleWebhook);
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+        System.out.println("GitHub Webhook 서버 시작 (포트: " + port + ")");
+        System.out.println("GitHub 레포 → Settings → Webhooks 에 아래 URL 등록하세요:");
+        System.out.println("  http://<your-public-ip>:" + port + "/webhook");
+    }
+
+    public void stop() {
+        if (server != null) {
+            server.stop(0);
+            System.out.println("GitHub Webhook 서버 종료");
+        }
+    }
+
+    public boolean isRunning() {
+        return server != null;
+    }
+
+    public void setEventListener(Consumer<WebhookEvent> listener) {
+        this.eventListener = listener;
+    }
+
+    public List<WebhookEvent> getReceivedEvents() {
+        return Collections.unmodifiableList(receivedEvents);
+    }
+
+    private void handleWebhook(HttpExchange exchange) throws IOException {
+        if (!"POST".equals(exchange.getRequestMethod())) {
+            exchange.sendResponseHeaders(405, -1);
+            return;
+        }
+
+        String eventType = exchange.getRequestHeaders().getFirst("X-GitHub-Event");
+        String body = readBody(exchange.getRequestBody());
+
+        try {
+            WebhookEvent event = parseEvent(eventType, body);
+            if (event != null) {
+                receivedEvents.add(event);
+                if (eventListener != null) {
+                    eventListener.accept(event);
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Webhook 파싱 오류: " + e.getMessage());
+        }
+
+        String response = "{\"status\":\"ok\"}";
+        byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.getResponseBody().close();
+    }
+
+    private WebhookEvent parseEvent(String eventType, String body) {
+        if (!"issues".equals(eventType) && !"pull_request".equals(eventType)) {
+            return null;
+        }
+
+        JsonObject json = JsonParser.parseString(body).getAsJsonObject();
+        String action = json.has("action") ? json.get("action").getAsString() : "unknown";
+
+        // 신규 오픈된 이벤트만 처리
+        if (!"opened".equals(action)) return null;
+
+        String repo = json.getAsJsonObject("repository").get("full_name").getAsString();
+
+        JsonObject target = "issues".equals(eventType)
+                ? json.getAsJsonObject("issue")
+                : json.getAsJsonObject("pull_request");
+
+        String title = target.get("title").getAsString();
+        String url = target.get("html_url").getAsString();
+
+        JsonElement userEl = target.get("user");
+        String author = (userEl != null && !userEl.isJsonNull())
+                ? userEl.getAsJsonObject().get("login").getAsString()
+                : "unknown";
+
+        String type = "issues".equals(eventType) ? "issue" : "pull_request";
+        return new WebhookEvent(type, action, repo, title, url, author);
+    }
+
+    private String readBody(InputStream is) throws IOException {
+        return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/gitalk/api/HackerNewsClient.java
+++ b/src/main/java/com/gitalk/api/HackerNewsClient.java
@@ -1,0 +1,79 @@
+package com.gitalk.api;
+
+import com.gitalk.model.NewsItem;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HackerNewsClient {
+
+    private static final String BASE_URL = "https://hacker-news.firebaseio.com/v0";
+    private final HttpClient httpClient;
+
+    public HackerNewsClient() {
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    /**
+     * HackerNews Top Stories 중 상위 count개를 가져옵니다.
+     */
+    public List<NewsItem> fetchTopStories(int count) throws Exception {
+        String idsJson = get(BASE_URL + "/topstories.json");
+        JsonArray ids = JsonParser.parseString(idsJson).getAsJsonArray();
+
+        List<NewsItem> items = new ArrayList<>();
+        int limit = Math.min(count, ids.size());
+
+        for (int i = 0; i < limit; i++) {
+            int id = ids.get(i).getAsInt();
+            try {
+                NewsItem item = fetchItem(id);
+                if (item != null) {
+                    items.add(item);
+                }
+            } catch (Exception e) {
+                // 개별 아이템 실패 시 건너뜀
+            }
+        }
+        return items;
+    }
+
+    private NewsItem fetchItem(int id) throws Exception {
+        String json = get(BASE_URL + "/item/" + id + ".json");
+        if (json == null || json.equals("null")) return null;
+
+        JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
+
+        String type = obj.has("type") ? obj.get("type").getAsString() : "";
+        if (!"story".equals(type)) return null;
+
+        String title = obj.has("title") ? obj.get("title").getAsString() : "(제목 없음)";
+        String url = obj.has("url") ? obj.get("url").getAsString() : null;
+        int score = obj.has("score") ? obj.get("score").getAsInt() : 0;
+        String by = obj.has("by") ? obj.get("by").getAsString() : "unknown";
+        long time = obj.has("time") ? obj.get("time").getAsLong() : 0L;
+
+        return new NewsItem(id, title, url, score, by, time);
+    }
+
+    private String get(String url) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(10))
+                .GET()
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        return response.body();
+    }
+}

--- a/src/main/java/com/gitalk/api/OpenAIClient.java
+++ b/src/main/java/com/gitalk/api/OpenAIClient.java
@@ -1,0 +1,63 @@
+package com.gitalk.api;
+
+import com.gitalk.util.AppConfig;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public class OpenAIClient {
+
+    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+    private final HttpClient httpClient;
+    private final String apiKey;
+    private final String model;
+
+    public OpenAIClient() {
+        this.apiKey = AppConfig.get("openai.api.key");
+        this.model = AppConfig.get("openai.model");
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    public String analyze(String prompt) throws Exception {
+        JsonObject message = new JsonObject();
+        message.addProperty("role", "user");
+        message.addProperty("content", prompt);
+
+        JsonArray messages = new JsonArray();
+        messages.add(message);
+
+        JsonObject body = new JsonObject();
+        body.addProperty("model", model);
+        body.add("messages", messages);
+        body.addProperty("max_tokens", 1000);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(API_URL))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + apiKey)
+                .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() != 200) {
+            throw new RuntimeException("OpenAI API 오류: " + response.statusCode() + " " + response.body());
+        }
+
+        JsonObject json = JsonParser.parseString(response.body()).getAsJsonObject();
+        return json.getAsJsonArray("choices")
+                .get(0).getAsJsonObject()
+                .getAsJsonObject("message")
+                .get("content").getAsString()
+                .trim();
+    }
+}

--- a/src/main/java/com/gitalk/chatbot/ChatBot.java
+++ b/src/main/java/com/gitalk/chatbot/ChatBot.java
@@ -1,0 +1,158 @@
+package com.gitalk.chatbot;
+
+import com.gitalk.api.GithubTrendingClient;
+import com.gitalk.api.GithubWebhookServer;
+import com.gitalk.api.HackerNewsClient;
+import com.gitalk.api.OpenAIClient;
+import com.gitalk.model.NewsItem;
+import com.gitalk.model.TrendingRepo;
+import com.gitalk.model.WebhookEvent;
+
+import java.util.List;
+
+public class ChatBot {
+
+    private final GithubTrendingClient trendingClient = new GithubTrendingClient();
+    private final HackerNewsClient hackerNewsClient = new HackerNewsClient();
+    private final OpenAIClient openAIClient = new OpenAIClient();
+    private final GithubWebhookServer webhookServer = new GithubWebhookServer();
+
+    public void handleCommand(String input) {
+        String[] parts = input.trim().split("\\s+", 2);
+        String command = parts[0].toLowerCase();
+
+        switch (command) {
+            case "trend" -> handleTrend(parts.length > 1 ? parts[1].trim() : null);
+            case "news" -> handleNews();
+            case "webhook" -> {
+                String sub = parts.length > 1 ? parts[1].toLowerCase() : "";
+                handleWebhook(sub);
+            }
+            case "help" -> printHelp();
+            default -> System.out.println("알 수 없는 명령어입니다. 'help' 를 입력하세요.");
+        }
+    }
+
+    // ── 기능 1: GitHub Trending + OpenAI 분석 ──────────────────────────────
+
+    private void handleTrend(String filter) {
+        String filterDesc = filter == null ? "전체" :
+                filter.startsWith("topic:") ? "주제: " + filter.substring(6) : "언어: " + filter;
+        System.out.println("\n GitHub 트렌딩 레포지토리 분석 중... [" + filterDesc + "]\n");
+        try {
+            List<TrendingRepo> repos = trendingClient.fetchTrending(5, filter);
+            if (repos.isEmpty()) {
+                System.out.println("트렌딩 데이터를 가져오지 못했습니다.");
+                return;
+            }
+
+            StringBuilder prompt = new StringBuilder();
+            prompt.append("다음은 최근 7일간 GitHub에서 가장 많은 스타를 받은 레포지토리 목록입니다 [").append(filterDesc).append("].\n");
+            prompt.append("각 레포지토리가 왜 인기 있는지 한국어로 간략하게 분석해주세요.\n\n");
+
+            for (int i = 0; i < repos.size(); i++) {
+                TrendingRepo repo = repos.get(i);
+                prompt.append(i + 1).append(". ").append(repo.fullName()).append("\n");
+                prompt.append("   스타: ").append(repo.stars()).append("\n");
+                prompt.append("   언어: ").append(repo.language()).append("\n");
+                prompt.append("   설명: ").append(repo.description()).append("\n\n");
+            }
+
+            System.out.println("=== GitHub 트렌딩 TOP 5 ===\n");
+            for (int i = 0; i < repos.size(); i++) {
+                System.out.println((i + 1) + ". " + repos.get(i));
+                System.out.println();
+            }
+
+            System.out.println("OpenAI 분석 중...\n");
+            String analysis = openAIClient.analyze(prompt.toString());
+            System.out.println("=== AI 분석 결과 ===\n");
+            System.out.println(analysis);
+            System.out.println();
+
+        } catch (Exception e) {
+            System.err.println("트렌딩 조회 실패: " + e.getMessage());
+        }
+    }
+
+    // ── 기능 2: HackerNews 뉴스 ────────────────────────────────────────────
+
+    private void handleNews() {
+        System.out.println("\n HackerNews 개발자 뉴스 가져오는 중...\n");
+        try {
+            List<NewsItem> items = hackerNewsClient.fetchTopStories(10);
+            if (items.isEmpty()) {
+                System.out.println("뉴스를 가져오지 못했습니다.");
+                return;
+            }
+
+            System.out.println("=== HackerNews Top 10 ===\n");
+            for (int i = 0; i < items.size(); i++) {
+                System.out.println((i + 1) + ". " + items.get(i));
+                System.out.println();
+            }
+        } catch (Exception e) {
+            System.err.println("뉴스 조회 실패: " + e.getMessage());
+        }
+    }
+
+    // ── 기능 3: GitHub Webhook ─────────────────────────────────────────────
+
+    private void handleWebhook(String sub) {
+        switch (sub) {
+            case "start" -> {
+                if (webhookServer.isRunning()) {
+                    System.out.println("웹훅 서버가 이미 실행 중입니다.");
+                    return;
+                }
+                try {
+                    webhookServer.setEventListener(this::printWebhookEvent);
+                    webhookServer.start();
+                } catch (Exception e) {
+                    System.err.println("웹훅 서버 시작 실패: " + e.getMessage());
+                }
+            }
+            case "stop" -> {
+                webhookServer.stop();
+            }
+            case "list" -> {
+                List<WebhookEvent> events = webhookServer.getReceivedEvents();
+                if (events.isEmpty()) {
+                    System.out.println("수신된 웹훅 이벤트가 없습니다.");
+                } else {
+                    System.out.println("=== 수신된 이벤트 (" + events.size() + "건) ===\n");
+                    events.forEach(e -> {
+                        System.out.println(e);
+                        System.out.println();
+                    });
+                }
+            }
+            default -> System.out.println("사용법: webhook start | webhook stop | webhook list");
+        }
+    }
+
+    private void printWebhookEvent(WebhookEvent event) {
+        System.out.println("\n[Webhook 수신] " + event);
+        System.out.print("> ");
+    }
+
+    // ── 도움말 ─────────────────────────────────────────────────────────────
+
+    public void printHelp() {
+        System.out.println("""
+
+                ╔══════════════════════════════════════════╗
+                ║         Gitalk 명령어 목록               ║
+                ╠══════════════════════════════════════════╣
+                ║  trend [필터]   GitHub 트렌딩 + AI 분석  ║
+                ║    예) trend java / trend topic:ai      ║
+                ║  news           HackerNews 개발자 뉴스   ║
+                ║  webhook start  웹훅 서버 시작            ║
+                ║  webhook stop   웹훅 서버 종료            ║
+                ║  webhook list   수신된 이벤트 목록        ║
+                ║  help           도움말                   ║
+                ║  exit           종료                     ║
+                ╚══════════════════════════════════════════╝
+                """);
+    }
+}

--- a/src/main/java/com/gitalk/model/NewsItem.java
+++ b/src/main/java/com/gitalk/model/NewsItem.java
@@ -1,0 +1,24 @@
+package com.gitalk.model;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+public record NewsItem(
+        int id,
+        String title,
+        String url,
+        int score,
+        String by,
+        long time
+) {
+    @Override
+    public String toString() {
+        String link = url != null ? url : "https://news.ycombinator.com/item?id=" + id;
+        LocalDateTime dt = LocalDateTime.ofInstant(Instant.ofEpochSecond(time), ZoneId.of("Asia/Seoul"));
+        String formatted = dt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        return String.format("▶ %s\n  점수: %d | 작성자: %s | %s\n  %s",
+                title, score, by, formatted, link);
+    }
+}

--- a/src/main/java/com/gitalk/model/TrendingRepo.java
+++ b/src/main/java/com/gitalk/model/TrendingRepo.java
@@ -1,0 +1,19 @@
+package com.gitalk.model;
+
+public record TrendingRepo(
+        String fullName,
+        String description,
+        int stars,
+        String language,
+        String url
+) {
+    @Override
+    public String toString() {
+        return String.format("[%s] ⭐ %,d | %s\n  %s\n  %s",
+                language != null ? language : "N/A",
+                stars,
+                fullName,
+                description != null ? description : "(설명 없음)",
+                url);
+    }
+}

--- a/src/main/java/com/gitalk/model/WebhookEvent.java
+++ b/src/main/java/com/gitalk/model/WebhookEvent.java
@@ -1,0 +1,26 @@
+package com.gitalk.model;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public record WebhookEvent(
+        String type,      // "issue" | "pull_request"
+        String action,
+        String repo,
+        String title,
+        String url,
+        String author,
+        LocalDateTime receivedAt
+) {
+    public WebhookEvent(String type, String action, String repo, String title, String url, String author) {
+        this(type, action, repo, title, url, author, LocalDateTime.now());
+    }
+
+    @Override
+    public String toString() {
+        String icon = "pull_request".equals(type) ? "PR" : "Issue";
+        return String.format("[%s] %s | %s\n  레포: %s | 작성자: %s\n  %s\n  받은 시각: %s",
+                icon, action, title, repo, author, url,
+                receivedAt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
+    }
+}

--- a/src/main/java/com/gitalk/util/AppConfig.java
+++ b/src/main/java/com/gitalk/util/AppConfig.java
@@ -1,0 +1,27 @@
+package com.gitalk.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class AppConfig {
+
+    private static final Properties props = new Properties();
+
+    static {
+        try (InputStream in = AppConfig.class.getClassLoader().getResourceAsStream("config.properties")) {
+            if (in == null) throw new RuntimeException("config.properties 를 찾을 수 없습니다.");
+            props.load(in);
+        } catch (IOException e) {
+            throw new RuntimeException("설정 파일 로드 실패", e);
+        }
+    }
+
+    public static String get(String key) {
+        return props.getProperty(key);
+    }
+
+    public static int getInt(String key) {
+        return Integer.parseInt(props.getProperty(key));
+    }
+}

--- a/src/main/resources/config.properties.example
+++ b/src/main/resources/config.properties.example
@@ -1,0 +1,6 @@
+openai.api.key=YOUR_OPENAI_API_KEY
+openai.model=gpt-4o-mini
+
+github.token=YOUR_GITHUB_TOKEN
+
+webhook.server.port=8080


### PR DESCRIPTION
## 관련 이슈
- closes #

## 작업 내용
Java 21 기반 CLI 챗봇 Gitalk의 초기 프로젝트 구조를 세팅합니다.

## 변경 사항
- [x] 기능 구현

## 구현 내용 상세

### 패키지 구조
```
src/main/java/com/gitalk/
├── GitalkApplication.java       # CLI 진입점 및 명령어 루프
├── api/
│   ├── GithubTrendingClient.java  # GitHub Search API 연동 (트렌딩)
│   ├── OpenAIClient.java          # OpenAI Chat Completions 연동
│   ├── HackerNewsClient.java      # HackerNews API 연동
│   └── GithubWebhookServer.java   # GitHub Webhook 수신 서버
├── chatbot/
│   └── ChatBot.java               # 명령어 라우팅 및 기능 조합
├── model/
│   ├── TrendingRepo.java          # GitHub 트렌딩 레포 모델 (record)
│   ├── NewsItem.java              # HackerNews 뉴스 모델 (record)
│   └── WebhookEvent.java          # Webhook 이벤트 모델 (record)
└── util/
    └── AppConfig.java             # config.properties 로더
```

### 지원 명령어
| 명령어 | 설명 |
|---|---|
| `trend [필터]` | GitHub 트렌딩 + OpenAI 분석 (`trend java`, `trend topic:ai`) |
| `news` | HackerNews Top 10 뉴스 |
| `webhook start\|stop\|list` | GitHub Webhook 서버 관리 |

### 기타
- DB 관련 작업은 별도 PR로 분리
- API 키는 `config.properties.example` 참고하여 로컬에서 `config.properties` 생성

## 테스트 결과
- [x] 로컬 컴파일 확인 (`./compile.sh`)
- [x] `trend`, `news` 명령어 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)