### PR TITLE
Feat/#20/gtihub oauth login 구현

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -10,10 +10,12 @@ USE gitalkdb;
 CREATE TABLE IF NOT EXISTS users (
                                      userid       BIGINT AUTO_INCREMENT PRIMARY KEY,
                                      email        VARCHAR(255) NOT NULL UNIQUE,
-    password     VARCHAR(255) NOT NULL,
+    password     VARCHAR(255),
     nickname     VARCHAR(100),
     profile_url  VARCHAR(255),
     type         VARCHAR(50),
+    github_id    BIGINT NULL UNIQUE,
+    auth_access_token VARCHAR(255) NULL,
     created_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
 

--- a/src/main/java/com/gitalk/GitalkApplication.java
+++ b/src/main/java/com/gitalk/GitalkApplication.java
@@ -8,6 +8,9 @@ import com.gitalk.domain.chatbot.service.NewsService;
 import com.gitalk.domain.chatbot.service.TrendingService;
 import com.gitalk.domain.chatbot.service.WebhookService;
 import com.gitalk.domain.chatbot.view.ChatBotView;
+import com.gitalk.domain.oauth.github.service.GithubAuthService;
+import com.gitalk.domain.oauth.github.service.GithubOauthClient;
+import com.gitalk.domain.user.model.Users;
 import com.gitalk.domain.user.repository.UserRepository;
 import com.gitalk.domain.user.service.UserService;
 import com.gitalk.domain.user.view.JoinAndLoginView;
@@ -42,8 +45,10 @@ public class GitalkApplication {
         // 2. 로그인 / 회원가입
         UserRepository userRepository = new UserRepository();
         UserService userService = new UserService(userRepository);
-        JoinAndLoginView joinAndLoginView = new JoinAndLoginView(userService);
-        joinAndLoginView.start();
+        GithubOauthClient githubOauthClient = new GithubOauthClient();
+        GithubAuthService githubAuthService = new GithubAuthService(userRepository, githubOauthClient);
+        JoinAndLoginView joinAndLoginView = new JoinAndLoginView(userService, githubAuthService);
+        Users loginUser = joinAndLoginView.start();
 
         // 3. 챗봇 진입
         mainView.clearScreen();

--- a/src/main/java/com/gitalk/domain/oauth/github/exception/GithubAuthorizationPendingException.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/exception/GithubAuthorizationPendingException.java
@@ -1,0 +1,14 @@
+package com.gitalk.domain.oauth.github.exception;
+
+/**
+ * GithubAuthorizationPendingException Description :
+ * NOTE :
+ *
+ * @author jki
+ * @since 04-08 (수) 오후 5:41
+ */
+public class GithubAuthorizationPendingException extends RuntimeException {
+    public GithubAuthorizationPendingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/gitalk/domain/oauth/github/model/GithubDeviceCode.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/model/GithubDeviceCode.java
@@ -1,0 +1,44 @@
+package com.gitalk.domain.oauth.github.model;
+
+/**
+ * GithubDeviceCode Description :
+ * NOTE :
+ *
+ * @author jki
+ * @since 04-08 (수) 오후 4:56
+ */
+public class GithubDeviceCode {
+    private final String deviceCode;
+    private final String userCode;
+    private final String verificationUri;
+    private final int interval;
+    private final int expiresIn;
+
+    public GithubDeviceCode(String deviceCode, String userCode, String verificationUri, int interval, int expiresIn) {
+        this.deviceCode = deviceCode;
+        this.userCode = userCode;
+        this.verificationUri = verificationUri;
+        this.interval = interval;
+        this.expiresIn = expiresIn;
+    }
+
+    public String getDeviceCode() {
+        return deviceCode;
+    }
+
+    public String getUserCode() {
+        return userCode;
+    }
+
+    public String getVerificationUri() {
+        return verificationUri;
+    }
+
+    public int getInterval() {
+        return interval;
+    }
+
+    public int getExpiresIn() {
+        return expiresIn;
+    }
+}

--- a/src/main/java/com/gitalk/domain/oauth/github/model/GithubUserInfo.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/model/GithubUserInfo.java
@@ -1,0 +1,38 @@
+package com.gitalk.domain.oauth.github.model;
+
+/**
+ * GithubUserInfo Description :
+ * NOTE :
+ *
+ * @author jki
+ * @since 04-08 (수) 오후 4:56
+ */
+public class GithubUserInfo {
+    private final Long id;
+    private final String login;
+    private final String email;
+    private final String avatarUrl;
+
+    public GithubUserInfo(Long id, String login, String email, String avatarUrl) {
+        this.id = id;
+        this.login = login;
+        this.email = email;
+        this.avatarUrl = avatarUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getLogin() {
+        return login;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+}

--- a/src/main/java/com/gitalk/domain/oauth/github/service/GithubAuthService.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/service/GithubAuthService.java
@@ -1,0 +1,58 @@
+package com.gitalk.domain.oauth.github.service;
+import com.gitalk.domain.oauth.github.model.GithubDeviceCode;
+import com.gitalk.domain.oauth.github.model.GithubUserInfo;
+import com.gitalk.domain.user.model.Users;
+import com.gitalk.domain.user.repository.UserRepository;
+
+/**
+ * GithubAuthService Description :
+ * NOTE :
+ *
+ * @author jki
+ * @since 04-08 (수) 오후 4:57
+ */
+public class GithubAuthService {
+
+    private final UserRepository userRepository;
+    private final GithubOauthClient githubOauthClient;
+
+    public GithubAuthService(UserRepository userRepository, GithubOauthClient githubOauthClient) {
+        this.userRepository = userRepository;
+        this.githubOauthClient = githubOauthClient;
+    }
+
+    public GithubDeviceCode requestDeviceCode() {
+        return githubOauthClient.requestDeviceCode();
+    }
+
+    public String requestAccessTokenOnce(GithubDeviceCode deviceCode) {
+        return githubOauthClient.requestAccessTokenOnce(deviceCode);
+    }
+
+    public Users loginOrRegisterByAccessToken(String accessToken) {
+        GithubUserInfo githubUser = githubOauthClient.fetchGithubUser(accessToken);
+
+        return userRepository.findByGithubId(githubUser.getId())
+                .orElseGet(() -> registerGithubUser(githubUser, accessToken));
+    }
+
+    private Users registerGithubUser(GithubUserInfo githubUser, String accessToken) {
+        if (userRepository.existsByEmail(githubUser.getEmail())) {
+            throw new RuntimeException("이미 같은 이메일의 계정이 존재합니다.");
+        }
+
+        Users user = new Users.Builder()
+                .githubId(githubUser.getId())
+                .email(githubUser.getEmail())
+                .nickname(githubUser.getLogin())
+                .profileUrl(githubUser.getAvatarUrl())
+                .type("GITHUB")
+                .authAccessToken(accessToken)
+                .build();
+
+        userRepository.save(user);
+
+        return userRepository.findByGithubId(githubUser.getId())
+                .orElseThrow(() -> new RuntimeException("GitHub 회원 저장 후 조회 실패"));
+    }
+}

--- a/src/main/java/com/gitalk/domain/oauth/github/service/GithubOauthClient.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/service/GithubOauthClient.java
@@ -1,0 +1,520 @@
+package com.gitalk.domain.oauth.github.service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.gitalk.common.util.AppConfig;
+import com.gitalk.domain.oauth.github.exception.GithubAuthorizationPendingException;
+import com.gitalk.domain.oauth.github.model.GithubDeviceCode;
+import com.gitalk.domain.oauth.github.model.GithubUserInfo;
+
+/**
+ * GithubOauthClient Description :
+ * NOTE :
+ *
+ * @author jki
+ * @since 04-08 (수) 오후 4:58
+ */
+public class GithubOauthClient {
+
+    private static final String FORM_URLENCODED = "application/x-www-form-urlencoded";
+    private static final String ACCEPT_JSON = "application/json";
+    private static final String ACCEPT_GITHUB_JSON = "application/vnd.github+json";
+
+    private final HttpClient httpClient;
+
+    public GithubOauthClient() {
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    /**
+     * 1) Device Code 발급
+     */
+    public GithubDeviceCode requestDeviceCode() {
+        String deviceCodeUrl = getRequiredProperty("github.device.code.url");
+        String clientId = getRequiredProperty("github.client.id");
+        String scope = getPropertyOrDefault("github.oauth.scope", "read:user user:email");
+
+        String requestBody = formData(
+                "client_id", clientId,
+                "scope", scope
+        );
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(deviceCodeUrl))
+                .timeout(Duration.ofSeconds(10))
+                .header("Accept", ACCEPT_JSON)
+                .header("Content-Type", FORM_URLENCODED)
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        String responseBody = send(request, "Device Code 발급");
+
+        // GitHub가 200으로 에러를 내려주는 경우도 있으니 body 내부 에러 체크
+        validateOAuthErrorResponse(responseBody, "Device Code 발급 실패");
+
+        String deviceCode = extractString(responseBody, "device_code");
+        String userCode = extractString(responseBody, "user_code");
+        String verificationUri = extractString(responseBody, "verification_uri");
+        int expiresIn = extractInt(responseBody, "expires_in", 900);
+        int interval = extractInt(responseBody, "interval", 5);
+
+        if (isBlank(deviceCode)) {
+            throw new RuntimeException("GitHub 응답에 device_code가 없습니다. response=" + responseBody);
+        }
+        if (isBlank(userCode)) {
+            throw new RuntimeException("GitHub 응답에 user_code가 없습니다. response=" + responseBody);
+        }
+        if (isBlank(verificationUri)) {
+            throw new RuntimeException("GitHub 응답에 verification_uri가 없습니다. response=" + responseBody);
+        }
+
+        return new GithubDeviceCode(
+                deviceCode,
+                userCode,
+                verificationUri,
+                interval,
+                expiresIn
+        );
+    }
+
+    /**
+     * 2) 승인 완료까지 polling 해서 access token 발급
+     *
+     * Device Flow는 client_id, device_code, grant_type 중심으로 polling 한다.
+     */
+    public String pollAccessToken(GithubDeviceCode deviceCode) {
+        if (deviceCode == null) {
+            throw new IllegalArgumentException("deviceCode는 필수입니다.");
+        }
+
+        String accessTokenUrl = getRequiredProperty("github.access.token.url");
+        String clientId = getRequiredProperty("github.client.id");
+        int pollTimeoutSeconds = getIntProperty("github.oauth.poll.timeout.seconds", 300);
+
+        long startedAt = System.currentTimeMillis();
+        long deadline = startedAt + pollTimeoutSeconds * 1000L;
+        int intervalSeconds = Math.max(deviceCode.getInterval(), 1);
+
+        while (System.currentTimeMillis() < deadline) {
+            String requestBody = formData(
+                    "client_id", clientId,
+                    "device_code", deviceCode.getDeviceCode(),
+                    "grant_type", "urn:ietf:params:oauth:grant-type:device_code"
+            );
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(accessTokenUrl))
+                    .timeout(Duration.ofSeconds(10))
+                    .header("Accept", ACCEPT_JSON)
+                    .header("Content-Type", FORM_URLENCODED)
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                    .build();
+
+            String responseBody = send(request, "Access Token polling");
+
+            String accessToken = extractString(responseBody, "access_token");
+            if (!isBlank(accessToken)) {
+                return accessToken;
+            }
+
+            String error = extractString(responseBody, "error");
+            String errorDescription = extractString(responseBody, "error_description");
+
+            if (isBlank(error)) {
+                throw new RuntimeException("GitHub access token 응답 형식이 올바르지 않습니다. response=" + responseBody);
+            }
+
+            switch (error) {
+                case "authorization_pending":
+                    sleepSeconds(intervalSeconds);
+                    break;
+
+                case "slow_down":
+                    intervalSeconds += 5;
+                    sleepSeconds(intervalSeconds);
+                    break;
+
+                case "expired_token":
+                    throw new RuntimeException("GitHub 인증 코드가 만료되었습니다. 다시 로그인해주세요.");
+
+                case "access_denied":
+                    throw new RuntimeException("사용자가 GitHub 로그인을 승인하지 않았습니다.");
+
+                case "unsupported_grant_type":
+                    throw new RuntimeException("grant_type 설정이 올바르지 않습니다.");
+
+                case "incorrect_client_credentials":
+                    throw new RuntimeException("github.client.id 설정이 올바르지 않습니다.");
+
+                case "bad_verification_code":
+                    throw new RuntimeException("device_code가 유효하지 않습니다. 다시 로그인해주세요.");
+
+                case "device_flow_disabled":
+                    throw new RuntimeException("GitHub OAuth App에서 Device Flow가 비활성화되어 있습니다. GitHub 설정에서 Enable Device Flow를 켜야 합니다.");
+
+                default:
+                    throw new RuntimeException("GitHub 토큰 발급 실패: " +
+                            (!isBlank(errorDescription) ? errorDescription : error));
+            }
+        }
+
+        throw new RuntimeException("GitHub 로그인 승인 대기 시간이 초과되었습니다.");
+    }
+
+    /**
+     * 3) GitHub 사용자 정보 조회
+     * email이 /user 응답에 없으면 /user/emails 추가 조회
+     */
+    public GithubUserInfo fetchGithubUser(String accessToken) {
+        if (isBlank(accessToken)) {
+            throw new IllegalArgumentException("accessToken은 필수입니다.");
+        }
+
+        String userApiUrl = getRequiredProperty("github.api.user.url");
+        String userJson = requestGithubApi(userApiUrl, accessToken);
+
+        Long githubId = extractLong(userJson, "id");
+        String login = extractString(userJson, "login");
+        String email = extractString(userJson, "email");
+        String avatarUrl = extractString(userJson, "avatar_url");
+
+        if (githubId == null) {
+            throw new RuntimeException("GitHub 사용자 ID를 가져오지 못했습니다. response=" + userJson);
+        }
+
+        if (isBlank(email)) {
+            String emailsApiUrl = getRequiredProperty("github.api.emails.url");
+            String emailsJson = requestGithubApi(emailsApiUrl, accessToken);
+            email = extractPrimaryVerifiedEmail(emailsJson);
+        }
+
+        if (isBlank(email)) {
+            throw new RuntimeException("GitHub 계정에서 사용 가능한 이메일을 찾지 못했습니다. user:email scope와 이메일 공개/검증 상태를 확인하세요.");
+        }
+
+        if (isBlank(login)) {
+            login = email;
+        }
+
+        return new GithubUserInfo(githubId, login, email, avatarUrl);
+    }
+
+    private String requestGithubApi(String url, String accessToken) {
+        String apiVersion = getPropertyOrDefault("github.api.version", "2022-11-28");
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(10))
+                .header("Accept", ACCEPT_GITHUB_JSON)
+                .header("Authorization", "Bearer " + accessToken)
+                .header("X-GitHub-Api-Version", apiVersion)
+                .GET()
+                .build();
+
+        return send(request, "GitHub API 호출");
+    }
+
+    private String send(HttpRequest request, String actionName) {
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            int statusCode = response.statusCode();
+            String responseBody = response.body();
+
+            if (statusCode >= 200 && statusCode < 300) {
+                return responseBody;
+            }
+
+            String error = extractString(responseBody, "error");
+            String errorDescription = extractString(responseBody, "error_description");
+            String message = extractString(responseBody, "message");
+
+            String detail;
+            if (!isBlank(errorDescription)) {
+                detail = errorDescription;
+            } else if (!isBlank(message)) {
+                detail = message;
+            } else if (!isBlank(error)) {
+                detail = error;
+            } else {
+                detail = responseBody;
+            }
+
+            throw new RuntimeException(actionName + " 실패. status=" + statusCode + ", detail=" + detail);
+
+        } catch (IOException e) {
+            throw new RuntimeException(actionName + " 중 네트워크 오류가 발생했습니다.", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(actionName + " 중 인터럽트가 발생했습니다.", e);
+        }
+    }
+
+    private void validateOAuthErrorResponse(String responseBody, String defaultMessage) {
+        String error = extractString(responseBody, "error");
+        if (isBlank(error)) {
+            return;
+        }
+
+        String errorDescription = extractString(responseBody, "error_description");
+
+        switch (error) {
+            case "device_flow_disabled":
+                throw new RuntimeException("GitHub OAuth App에서 Device Flow가 비활성화되어 있습니다. GitHub 설정에서 Enable Device Flow를 켜야 합니다.");
+
+            case "incorrect_client_credentials":
+                throw new RuntimeException("github.client.id 설정이 올바르지 않습니다.");
+
+            default:
+                throw new RuntimeException(defaultMessage + ": " +
+                        (!isBlank(errorDescription) ? errorDescription : error));
+        }
+    }
+
+    public String requestAccessTokenOnce(GithubDeviceCode deviceCode) {
+        if (deviceCode == null) {
+            throw new IllegalArgumentException("deviceCode는 필수입니다.");
+        }
+
+        String accessTokenUrl = getRequiredProperty("github.access.token.url");
+        String clientId = getRequiredProperty("github.client.id");
+
+        String requestBody = formData(
+                "client_id", clientId,
+                "device_code", deviceCode.getDeviceCode(),
+                "grant_type", "urn:ietf:params:oauth:grant-type:device_code"
+        );
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(accessTokenUrl))
+                .timeout(Duration.ofSeconds(10))
+                .header("Accept", ACCEPT_JSON)
+                .header("Content-Type", FORM_URLENCODED)
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        String responseBody = send(request, "Access Token 확인");
+
+        String accessToken = extractString(responseBody, "access_token");
+        if (!isBlank(accessToken)) {
+            return accessToken;
+        }
+
+        String error = extractString(responseBody, "error");
+        String errorDescription = extractString(responseBody, "error_description");
+
+        if (isBlank(error)) {
+            throw new RuntimeException("GitHub access token 응답 형식이 올바르지 않습니다. response=" + responseBody);
+        }
+
+        switch (error) {
+            case "authorization_pending":
+                throw new GithubAuthorizationPendingException("아직 GitHub 승인이 완료되지 않았습니다.");
+
+            case "slow_down":
+                throw new GithubAuthorizationPendingException("아직 GitHub 승인이 완료되지 않았습니다.");
+
+            case "expired_token":
+                throw new RuntimeException("GitHub 인증 코드가 만료되었습니다. 다시 로그인해주세요.");
+
+            case "access_denied":
+                throw new RuntimeException("GitHub 로그인이 거부되었습니다.");
+
+            case "unsupported_grant_type":
+                throw new RuntimeException("grant_type 설정이 올바르지 않습니다.");
+
+            case "incorrect_client_credentials":
+                throw new RuntimeException("github.client.id 설정이 올바르지 않습니다.");
+
+            case "bad_verification_code":
+                throw new RuntimeException("device_code가 유효하지 않습니다. 다시 로그인해주세요.");
+
+            case "device_flow_disabled":
+                throw new RuntimeException("GitHub OAuth App에서 Device Flow가 비활성화되어 있습니다. GitHub 설정에서 Enable Device Flow를 켜야 합니다.");
+
+            default:
+                throw new RuntimeException("GitHub 토큰 발급 실패: " +
+                        (!isBlank(errorDescription) ? errorDescription : error));
+        }
+    }
+
+    private int getIntProperty(String key, int defaultValue) {
+        String value = getPropertyOrDefault(key, String.valueOf(defaultValue));
+
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new RuntimeException("설정값이 숫자가 아닙니다. key=" + key + ", value=" + value, e);
+        }
+    }
+
+    private String getRequiredProperty(String key) {
+        String value = AppConfig.get(key);
+
+        if (value == null || value.trim().isEmpty()) {
+            throw new RuntimeException("필수 설정값이 없습니다. key=" + key);
+        }
+
+        return value.trim();
+    }
+
+    private String getPropertyOrDefault(String key, String defaultValue) {
+        String value = AppConfig.get(key);
+        if (value == null || value.trim().isEmpty()) {
+            return defaultValue;
+        }
+        return value.trim();
+    }
+
+    private String formData(String... pairs) {
+        if (pairs == null || pairs.length == 0 || pairs.length % 2 != 0) {
+            throw new IllegalArgumentException("formData는 key/value 쌍으로 전달해야 합니다.");
+        }
+
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < pairs.length; i += 2) {
+            if (builder.length() > 0) {
+                builder.append("&");
+            }
+
+            builder.append(encode(pairs[i]))
+                    .append("=")
+                    .append(encode(pairs[i + 1]));
+        }
+
+        return builder.toString();
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value == null ? "" : value, StandardCharsets.UTF_8);
+    }
+
+    private void sleepSeconds(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("GitHub 승인 대기 중 인터럽트가 발생했습니다.", e);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private String extractString(String json, String key) {
+        if (json == null || key == null) {
+            return null;
+        }
+
+        Pattern pattern = Pattern.compile("\"" + Pattern.quote(key) + "\"\\s*:\\s*\"((?:\\\\.|[^\"])*)\"");
+        Matcher matcher = pattern.matcher(json);
+        if (matcher.find()) {
+            return unescapeJson(matcher.group(1));
+        }
+        return null;
+    }
+
+    private Integer extractInt(String json, String key, int defaultValue) {
+        if (json == null || key == null) {
+            return defaultValue;
+        }
+
+        Pattern pattern = Pattern.compile("\"" + Pattern.quote(key) + "\"\\s*:\\s*(\\d+)");
+        Matcher matcher = pattern.matcher(json);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1));
+        }
+        return defaultValue;
+    }
+
+    private Long extractLong(String json, String key) {
+        if (json == null || key == null) {
+            return null;
+        }
+
+        Pattern pattern = Pattern.compile("\"" + Pattern.quote(key) + "\"\\s*:\\s*(\\d+)");
+        Matcher matcher = pattern.matcher(json);
+        if (matcher.find()) {
+            return Long.parseLong(matcher.group(1));
+        }
+        return null;
+    }
+
+    private String extractBooleanText(String json, String key) {
+        if (json == null || key == null) {
+            return null;
+        }
+
+        Pattern pattern = Pattern.compile("\"" + Pattern.quote(key) + "\"\\s*:\\s*(true|false)");
+        Matcher matcher = pattern.matcher(json);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
+    }
+
+    private String extractPrimaryVerifiedEmail(String json) {
+        if (isBlank(json)) {
+            return null;
+        }
+
+        Pattern objectPattern = Pattern.compile("\\{(.*?)\\}", Pattern.DOTALL);
+        Matcher matcher = objectPattern.matcher(json);
+
+        String verifiedFallbackEmail = null;
+
+        while (matcher.find()) {
+            String objectJson = matcher.group();
+
+            String email = extractString(objectJson, "email");
+            String primaryText = extractBooleanText(objectJson, "primary");
+            String verifiedText = extractBooleanText(objectJson, "verified");
+
+            boolean primary = "true".equals(primaryText);
+            boolean verified = "true".equals(verifiedText);
+
+            if (isBlank(email)) {
+                continue;
+            }
+
+            if (primary && verified) {
+                return email;
+            }
+
+            if (verified && verifiedFallbackEmail == null) {
+                verifiedFallbackEmail = email;
+            }
+        }
+
+        return verifiedFallbackEmail;
+    }
+
+    private String unescapeJson(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        return value
+                .replace("\\\"", "\"")
+                .replace("\\\\", "\\")
+                .replace("\\/", "/")
+                .replace("\\b", "\b")
+                .replace("\\f", "\f")
+                .replace("\\n", "\n")
+                .replace("\\r", "\r")
+                .replace("\\t", "\t");
+    }
+}

--- a/src/main/java/com/gitalk/domain/user/model/Users.java
+++ b/src/main/java/com/gitalk/domain/user/model/Users.java
@@ -1,91 +1,60 @@
 package com.gitalk.domain.user.model;
 
-/**
- * users Description :
- * NOTE :
- *
- * @author jki
- * @since 04-07 (화) 오후 2:39
- */
 public class Users {
     private Long userid;
+    private Long githubId;
     private String email;
     private String password;
     private String nickname;
     private String profileUrl;
     private String type;
+    private String authAccessToken;
 
-    // getter / setter
-
-    public Users(Long userid, String email, String password, String nickname, String profileUrl, String type) {
-        this.userid = userid;
-        this.email = email;
-        this.password = password;
-        this.nickname = nickname;
-        this.profileUrl = profileUrl;
-        this.type = type;
-    }
-
-    // 기본 생성자 (외부에서 직접 생성 방지)
     private Users(Builder builder) {
         this.userid = builder.userid;
+        this.githubId = builder.githubId;
         this.email = builder.email;
         this.password = builder.password;
         this.nickname = builder.nickname;
         this.profileUrl = builder.profileUrl;
         this.type = builder.type;
+        this.authAccessToken = builder.authAccessToken;
     }
 
-    // Getter
     public Long getUserId() { return userid; }
+    public Long getGithubId() { return githubId; }
     public String getEmail() { return email; }
     public String getPassword() { return password; }
     public String getNickname() { return nickname; }
     public String getProfileUrl() { return profileUrl; }
     public String getType() { return type; }
+    public String getAuthAccessToken() { return authAccessToken; }
 
-    // Builder
     public static class Builder {
         private Long userid;
+        private Long githubId;
         private String email;
         private String password;
         private String nickname;
         private String profileUrl;
         private String type;
+        private String authAccessToken;
 
-        public Builder email(String email) {
-            this.email = email;
-            return this;
-        }
-
-        public Builder password(String password) {
-            this.password = password;
-            return this;
-        }
-
-        public Builder nickname(String nickname) {
-            this.nickname = nickname;
-            return this;
-        }
-
-        public Builder profileUrl(String profileUrl) {
-            this.profileUrl = profileUrl;
-            return this;
-        }
-
-        public Builder type(String type) {
-            this.type = type;
-            return this;
-        }
-
-        public Builder userid(Long userid) {
-            this.userid = userid;
-            return this;
-        }
+        public Builder userid(Long userid) { this.userid = userid; return this; }
+        public Builder githubId(Long githubId) { this.githubId = githubId; return this; }
+        public Builder email(String email) { this.email = email; return this; }
+        public Builder password(String password) { this.password = password; return this; }
+        public Builder nickname(String nickname) { this.nickname = nickname; return this; }
+        public Builder profileUrl(String profileUrl) { this.profileUrl = profileUrl; return this; }
+        public Builder type(String type) { this.type = type; return this; }
+        public Builder authAccessToken(String authAccessToken) { this.authAccessToken = authAccessToken; return this; }
 
         public Users build() {
-            if (email == null || password == null) {
-                throw new IllegalStateException("email과 password는 필수입니다.");
+            if (email == null || email.isBlank()) {
+                throw new IllegalStateException("email은 필수입니다.");
+            }
+            if (type == null || type.isBlank()) {
+                throw new IllegalStateException("type은 필수입니다.");
             }
             return new Users(this);
         }

--- a/src/main/java/com/gitalk/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gitalk/domain/user/repository/UserRepository.java
@@ -1,12 +1,9 @@
 package com.gitalk.domain.user.repository;
 
-import com.gitalk.domain.user.model.Users;
 import com.gitalk.common.util.DBConnection;
+import com.gitalk.domain.user.model.Users;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.Optional;
 
 public class UserRepository {
@@ -21,19 +18,29 @@ public class UserRepository {
             ResultSet rs = pstmt.executeQuery();
 
             if (rs.next()) {
-                Users user = new Users.Builder()
-                        .userid(rs.getLong("userid"))
-                        .email(rs.getString("email"))
-                        .password(rs.getString("password"))
-                        .build();
-
-                return Optional.of(user);
+                return Optional.of(map(rs));
             }
-
         } catch (SQLException e) {
             throw new RuntimeException("DB 조회 실패", e);
         }
+        return Optional.empty();
+    }
 
+    public Optional<Users> findByGithubId(Long githubId) {
+        String sql = "SELECT * FROM users WHERE github_id = ?";
+
+        try (Connection conn = DBConnection.makeConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            pstmt.setLong(1, githubId);
+            ResultSet rs = pstmt.executeQuery();
+
+            if (rs.next()) {
+                return Optional.of(map(rs));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("GitHub 사용자 조회 실패", e);
+        }
         return Optional.empty();
     }
 
@@ -50,7 +57,6 @@ public class UserRepository {
             if (rs.next()) {
                 return rs.getInt(1) > 0;
             }
-
         } catch (SQLException e) {
             throw new RuntimeException("이메일 중복 체크 실패", e);
         }
@@ -58,22 +64,58 @@ public class UserRepository {
     }
 
     // 회원 저장
+
     public void save(Users user) {
-        String sql = "INSERT INTO users (email, password, nickname, profile_url, type) VALUES (?, ?, ?, ?, ?)";
+        String sql = """
+            INSERT INTO users
+            (github_id, email, password, nickname, profile_url, type, auth_access_token)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """;
 
         try (Connection conn = DBConnection.makeConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
 
-            pstmt.setString(1, user.getEmail());
-            pstmt.setString(2, user.getPassword());
-            pstmt.setString(3, user.getNickname());
-            pstmt.setString(4, user.getProfileUrl());
-            pstmt.setString(5, user.getType());
+            if (user.getGithubId() != null) {
+                pstmt.setLong(1, user.getGithubId());
+            } else {
+                pstmt.setNull(1, java.sql.Types.BIGINT);
+            }
+
+            pstmt.setString(2, user.getEmail());
+
+            if (user.getPassword() != null) {
+                pstmt.setString(3, user.getPassword());
+            } else {
+                pstmt.setNull(3, java.sql.Types.VARCHAR);
+            }
+
+            pstmt.setString(4, user.getNickname());
+            pstmt.setString(5, user.getProfileUrl());
+            pstmt.setString(6, user.getType());
+
+            if (user.getAuthAccessToken() != null) {
+                pstmt.setString(7, user.getAuthAccessToken());
+            } else {
+                pstmt.setNull(7, java.sql.Types.VARCHAR);
+            }
 
             pstmt.executeUpdate();
 
         } catch (SQLException e) {
             throw new RuntimeException("회원 저장 실패", e);
         }
+    }
+
+    private Users map(ResultSet rs) throws SQLException {
+        return new Users.Builder()
+                .userid(rs.getLong("userid"))
+                .githubId(rs.getObject("github_id") != null ? rs.getLong("github_id") : null)
+                .email(rs.getString("email"))
+                .password(rs.getString("password"))
+                .nickname(rs.getString("nickname"))
+                .profileUrl(rs.getString("profile_url"))
+                .type(rs.getString("type"))
+                .authAccessToken(rs.getString("auth_access_token"))
+                .build();
     }
 }

--- a/src/main/java/com/gitalk/domain/user/service/UserService.java
+++ b/src/main/java/com/gitalk/domain/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.gitalk.domain.user.service;
 import com.gitalk.domain.user.model.Users;
 import com.gitalk.domain.user.repository.UserRepository;
 
+import java.security.MessageDigest;
+
 /**
  * UserService Description :
  * NOTE :
@@ -18,31 +20,29 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-
-    public boolean login(String email, String password) {
-
+    public Users login(String email, String password) {
         Users user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("로그인 및 비밀번호가 잘못되었습니다."));
+                .orElseThrow(() -> new RuntimeException("로그인 정보가 올바르지 않습니다."));
 
-        if (!user.getPassword().equals(encrypt(password))) {
-            throw new RuntimeException("로그인 및 비밀번호가 잘못되었습니다.");
+        if (!"LOCAL".equals(user.getType())) {
+            throw new RuntimeException("GitHub 회원입니다. GitHub 로그인을 사용하세요.");
         }
 
-        return true;
+        if (user.getPassword() == null || !user.getPassword().equals(encrypt(password))) {
+            throw new RuntimeException("로그인 정보가 올바르지 않습니다.");
+        }
+
+        return user;
     }
 
-
     public void register(String email, String password, String nickname) {
-
         if (userRepository.existsByEmail(email)) {
             throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
         }
 
-        String encryptedPassword = encrypt(password);
-
         Users user = new Users.Builder()
                 .email(email)
-                .password(encryptedPassword)
+                .password(encrypt(password))
                 .nickname(nickname)
                 .type("LOCAL")
                 .build();
@@ -52,7 +52,7 @@ public class UserService {
 
     private String encrypt(String password) {
         try {
-            java.security.MessageDigest md = java.security.MessageDigest.getInstance("SHA-256");
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
             byte[] hashed = md.digest(password.getBytes());
             StringBuilder sb = new StringBuilder();
             for (byte b : hashed) {

--- a/src/main/java/com/gitalk/domain/user/view/JoinAndLoginView.java
+++ b/src/main/java/com/gitalk/domain/user/view/JoinAndLoginView.java
@@ -7,65 +7,122 @@ package com.gitalk.domain.user.view;
  * @author jki
  * @since 04-07 (화) 오후 3:00
  */
+import com.gitalk.domain.oauth.github.model.GithubDeviceCode;
+import com.gitalk.domain.oauth.github.service.GithubAuthService;
+import com.gitalk.domain.user.model.Users;
 import com.gitalk.domain.user.service.UserService;
+import com.gitalk.domain.oauth.github.exception.GithubAuthorizationPendingException;
 
 import java.io.BufferedReader;
 import java.io.Console;
-import java.io.InputStreamReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 
 public class JoinAndLoginView {
 
-
     private final UserService userService;
+    private final GithubAuthService githubAuthService;
     private final BufferedReader reader;
     private final Console console;
 
-    public JoinAndLoginView(UserService userService) {
+    public JoinAndLoginView(UserService userService, GithubAuthService githubAuthService) {
         this.userService = userService;
+        this.githubAuthService = githubAuthService;
         this.reader = new BufferedReader(new InputStreamReader(System.in));
         this.console = System.console();
     }
 
-    public void start() {
-        outer:
+    public Users start() {
+        Users user;
         while (true) {
             try {
-                System.out.println("────────────────────────────────────────────────────────────────────");
-                System.out.println("   1. 로그인                      2. 회원가입");
-                System.out.println("────────────────────────────────────────────────────────────────────");
+                System.out.println("────────────────────────────────────────");
+                System.out.println("1. 로컬 로그인   2. GitHub 로그인   3. 회원가입   ");
+                System.out.println("────────────────────────────────────────");
                 System.out.print("선택: ");
 
                 String input = reader.readLine();
 
                 switch (input) {
                     case "1":
-                        if (login()) {
-                            break outer; // while 탈출
-                        } else {
-                            System.out.println("로그인 실패");
+                        user = login();
+                        if (user != null) {
+                            return user;
                         }
                         break;
-
                     case "2":
-                        if (signUp()) {
-                            break outer; // while 탈출
+                        user = githubLogin();
+                        if (user != null) {
+                            return user;
                         }
                         break;
-
+                    case "3":
+                        boolean signUpSuccess = signUp();
+                        if (signUpSuccess) {
+                            System.out.println("\n로그인을 진행해주세요.");
+                            user = login();
+                            if (user != null) {
+                                return user;
+                            }
+                        }
+                        break;
                     default:
                         System.out.println("잘못된 입력");
                 }
-
-            } catch (IOException e) {
-                System.out.println("입력 오류 발생");
+            } catch (Exception e) {
+                System.out.println("처리 실패: " + e.getMessage());
             }
         }
     }
 
+    private Users githubLogin() {
+        try {
+            GithubDeviceCode deviceCode = githubAuthService.requestDeviceCode();
 
-    public boolean signUp() {
+            System.out.println("\n[ GitHub 로그인 ]");
+            System.out.println("1. 아래 URL로 이동");
+            System.out.println("2. 아래 코드를 입력");
+            System.out.println("3. GitHub에서 승인");
+            System.out.println();
+            System.out.println("URL  : " + deviceCode.getVerificationUri());
+            System.out.println("CODE : " + deviceCode.getUserCode());
+            System.out.println();
 
+            int maxRetry = 5;
+
+            for (int attempt = 1; attempt <= maxRetry; attempt++) {
+                System.out.print("승인 완료 후 Enter > ");
+                reader.readLine();
+
+                try {
+                    String accessToken = githubAuthService.requestAccessTokenOnce(deviceCode);
+                    Users user = githubAuthService.loginOrRegisterByAccessToken(accessToken);
+                    System.out.println("GitHub 로그인 성공: " + user.getNickname());
+                    return user;
+
+                } catch (GithubAuthorizationPendingException e) {
+                    System.out.println("아직 GitHub 승인이 완료되지 않았습니다. (" + attempt + "/" + maxRetry + ")");
+                }
+            }
+
+            System.out.println("GitHub 승인 확인 횟수를 초과했습니다. 처음 화면으로 이동합니다.");
+            return null;
+
+        } catch (Exception e) {
+            System.out.println("GitHub 로그인 실패: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private Users login() throws IOException {
+        String email = inputEmail();
+        String password = inputPassword();
+        Users user = userService.login(email, password);
+        System.out.println("로그인 성공");
+        return user;
+    }
+
+    private boolean signUp() throws IOException {
         try {
             System.out.println("\n [ 회원가입 ]");
 
@@ -139,20 +196,6 @@ public class JoinAndLoginView {
             }
         }
     }
-
-    public boolean login() {
-        try {
-            String email = inputEmail();
-            String password = inputPassword();
-
-            return userService.login(email, password);
-
-        } catch (Exception e) {
-            System.out.println(e.getMessage());
-        }
-        return false;
-    }
-
 
     // ===== 유효성 메서드 =====
 


### PR DESCRIPTION
## 관련 이슈
- closes #20

---

## 작업 내용
- GitHub OAuth 기반 로그인 기능 구현
- Device Flow 기반 콘솔 인증 방식 적용

---

## 변경 사항
- [x] 기능 구현
- [ ] 기능 수정
- [ ] 문서 작업
- [ ] 테스트

---

## 구현 내용 상세

### 1. 사용자 엔티티 확장
- `githubId` 필드 추가
- `authAccessToken` 필드 추가 (로그인 용도가 아닌 GitHub API 호출용)

---

### 2. GitHub 로그인 Flow

1. Device Flow 시작 (`device_code`, `user_code` 발급)
2. 사용자 GitHub에서 코드 입력 및 승인
3. access_token 발급 요청
4. GitHub API로 사용자 정보 조회 (`id`, `email`, `avatar`)
5. `github_id` 기준 사용자 조회
6. 분기 처리
   - 존재하면 → 로그인 처리
   - 없으면 → 회원가입 후 로그인 처리

---

### 3. 로그인 정책

- GitHub 로그인은 `github_id` 기준으로 식별
- email은 보조 검증용 (중복 체크)
- access_token은 로그인 유지 용도가 아님

---

### 4. 구조 개선 사항

- polling 방식 → 사용자 Enter 기반 재시도 구조로 변경
- `authorization_pending` 상태를 별도 예외로 분리
- 최대 5회 재시도 후 로그인 화면으로 복귀

---

### 5. access_token 처리 방향

- 현재:
  - GitHub 사용자 정보 조회 시 1회 사용
- 향후:
  - webhook / repo 연동 기능 추가 시 GitHub API 호출 용도로 활용 예정
- 구조 개선:
  - `users` 테이블이 아닌 `github_integrations` 테이블로 분리 고려

---

## 테스트 결과

- [x] 로컬 실행 확인
- [x] GitHub 로그인 정상 동작 확인
- [x] 승인 전 재시도 로직 정상 동작 확인
- [ ] 기존 기능 정상 동작 확인

---

## 리뷰어에게

- `authAccessToken`을 users 테이블에 저장하는 구조 적절성 검토 요청
- webhook 기능 대비 integration 분리 설계 검토 요청
- Device Flow UX (Enter 기반 재시도 방식) 적절성 확인 요청

---

## 스크린샷 (선택)
- 없음