### PR TITLE
Feat/#26/채팅 내역 검색 기능 구현

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -2,30 +2,46 @@
 chcp 65001 >nul
 setlocal enabledelayedexpansion
 
-set SRC_DIR=src\main\java
-set RESOURCES_DIR=src\main\resources
-set OUT_DIR=out
-set LIB_DIR=lib
+REM Gitalk 컴파일 스크립트
 
-if not exist "%LIB_DIR%" (
-    echo lib 폴더 없음
+set "SRC_DIR=src\main\java"
+set "RESOURCES_DIR=src\main\resources"
+set "OUT_DIR=out"
+set "LIB_DIR=lib"
+set "BIN_DIR=src\main\java\com\gitalk\common\api\ImageToAscii\ascii-image-converter"
+
+REM lib 폴더에 JAR이 있는지 확인
+if not exist "%LIB_DIR%\*.jar" (
+    echo 오류: %LIB_DIR%\ 폴더에 JAR 파일이 없습니다.
+    echo 아래 파일을 다운로드해서 lib\ 에 넣어주세요:
+    echo   - mysql-connector-j-8.x.x.jar ^(https://dev.mysql.com/downloads/connector/j/^)
+    echo   - gson-2.x.x.jar              ^(https://github.com/google/gson/releases^)
     exit /b 1
 )
 
+REM Java 컴파일
 if not exist "%OUT_DIR%" mkdir "%OUT_DIR%"
 
-set SRC_FILES=
-for /R "%SRC_DIR%" %%f in (*.java) do (
-    set SRC_FILES=!SRC_FILES! "%%f"
+set "SRC_LIST=%TEMP%\gitalk_sources.txt"
+if exist "%SRC_LIST%" del "%SRC_LIST%"
+
+for /r "%SRC_DIR%" %%f in (*.java) do (
+    echo %%f | findstr /i /c:"ascii-image-converter" >nul
+    if errorlevel 1 (
+        echo %%f>>"%SRC_LIST%"
+    )
 )
 
-javac --release 21 -cp "%LIB_DIR%\*" -d "%OUT_DIR%" !SRC_FILES!
+javac -encoding UTF-8 --release 21 -cp "%LIB_DIR%\*" -d "%OUT_DIR%" @"%SRC_LIST%"
 
-if errorlevel 1 (
+if %errorlevel% equ 0 (
+    xcopy "%RESOURCES_DIR%\*" "%OUT_DIR%\" /e /i /y >nul
+    echo 컴파일 성공
+) else (
     echo 컴파일 실패
+    if exist "%SRC_LIST%" del "%SRC_LIST%"
     exit /b 1
 )
 
-xcopy "%RESOURCES_DIR%\*" "%OUT_DIR%\" /s /e /y >nul
-
-echo 컴파일 성공
+if exist "%SRC_LIST%" del "%SRC_LIST%"
+endlocal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,29 @@ services:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
 
     command:
-      --default-authentication-plugin=mysql_native_password
-      --character-set-server=utf8mb4
-      --collation-server=utf8mb4_unicode_ci
+      - --default-authentication-plugin=mysql_native_password
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+
+  mongodb:
+    image: mongo:8.0
+    container_name: mongodb-container
+    restart: always
+
+    ports:
+      - "27017:27017"
+
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: mongo_root
+      MONGO_INITDB_ROOT_PASSWORD: 1111
+      TZ: Asia/Seoul
+
+    volumes:
+      - mongo-data:/data/db
+
+    command:
+      - --quiet
 
 volumes:
   mysql-data:
+  mongo-data:

--- a/src/main/java/com/gitalk/GitalkApplication.java
+++ b/src/main/java/com/gitalk/GitalkApplication.java
@@ -209,6 +209,10 @@ public class GitalkApplication {
             String input = readLine();
             if (input == null || input.equals("0")) return;
 
+            if (handleGlobalSlashCommand(user, input)) {
+                continue;
+            }
+
             try {
                 int choice = Integer.parseInt(input);
                 if (choice < 1 || choice > notices.size()) continue;

--- a/src/main/java/com/gitalk/GitalkApplication.java
+++ b/src/main/java/com/gitalk/GitalkApplication.java
@@ -2,22 +2,23 @@ package com.gitalk;
 
 import com.gitalk.common.util.Layout;
 import com.gitalk.common.view.MainView;
+import com.gitalk.domain.chat.config.MongoConnectionManager;
 import com.gitalk.domain.chat.domain.ChatRoom;
 import com.gitalk.domain.chat.domain.Notice;
-import com.gitalk.domain.chat.repository.ChatRoomMemberRepositoryImpl;
-import com.gitalk.domain.chat.repository.ChatRoomRepositoryImpl;
-import com.gitalk.domain.chat.repository.NoticeRepositoryImpl;
+import com.gitalk.domain.chat.repository.*;
+import com.gitalk.domain.chat.search.service.ChatSearchService;
+import com.gitalk.domain.chat.search.service.SearchSessionManager;
 import com.gitalk.domain.chat.service.ChatRoomService;
+import com.gitalk.domain.chat.service.ChatService;
 import com.gitalk.domain.chat.service.NoticeService;
 import com.gitalk.domain.chat.session.ChatRoomSession;
 import com.gitalk.domain.chat.view.ChatRoomView;
+import com.gitalk.domain.chat.view.SearchView;
 import com.gitalk.domain.chatbot.service.NewsService;
 import com.gitalk.domain.chatbot.service.TrendingService;
 import com.gitalk.domain.chatbot.service.WebhookService;
-import com.gitalk.domain.chatbot.view.ChatBotView;
 import com.gitalk.domain.oauth.github.service.GithubAuthService;
 import com.gitalk.domain.oauth.github.service.GithubOauthClient;
-import com.gitalk.domain.user.model.Users;
 import com.gitalk.domain.user.model.Users;
 import com.gitalk.domain.user.repository.UserRepository;
 import com.gitalk.domain.user.service.UserService;
@@ -39,13 +40,35 @@ public class GitalkApplication {
     private static final MainView mainView = new MainView();
     private static final ChatRoomService chatRoomService = new ChatRoomService(
             new ChatRoomRepositoryImpl(), new ChatRoomMemberRepositoryImpl());
+
     private static final ChatRoomView chatRoomView = new ChatRoomView();
     private static final NoticeService noticeService = new NoticeService(new NoticeRepositoryImpl());
+
+    private static final MongoConnectionManager mongoConnectionManager = MongoConnectionManager.getInstance();
+
+    private static final MongoChatMessageRepository mongoChatMessageRepository =
+            new MongoChatMessageRepository(mongoConnectionManager);
+
+    private static final MongoSearchRepositoryImpl mongoSearchRepository =
+            new MongoSearchRepositoryImpl(mongoConnectionManager);
+
+    private static final ChatService chatService = new ChatService(mongoChatMessageRepository);
+
+    private static final ChatSearchService chatSearchService =
+            new ChatSearchService(mongoSearchRepository, chatService, chatRoomService);
+
+    private static final SearchSessionManager searchSessionManager = new SearchSessionManager();
+    private static final SearchView searchView = new SearchView();
+
+
     private static final ChatRoomSession chatRoomSession = new ChatRoomSession(
             trendingService, newsService, webhookService,
             new ChatRoomService(new ChatRoomRepositoryImpl(), new ChatRoomMemberRepositoryImpl()),
             new UserService(new UserRepository()),
-            noticeService);
+            noticeService,
+            chatSearchService, searchSessionManager, searchView
+            );
+
     private static UserService userService;
     private static BufferedReader reader;
 

--- a/src/main/java/com/gitalk/GitalkApplication.java
+++ b/src/main/java/com/gitalk/GitalkApplication.java
@@ -105,6 +105,10 @@ public class GitalkApplication {
                 return;
             }
 
+            if (handleGlobalSlashCommand(user, choice)) {
+                continue;
+            }
+
             switch (choice.trim()) {
                 case "1" -> runChatRoom(user);
                 case "2" -> runNoticeBoard(user);
@@ -150,6 +154,10 @@ public class GitalkApplication {
             String input = readLine();
             if (input == null || input.equals("0")) return;
 
+            if (handleGlobalSlashCommand(user, input)) {
+                continue;
+            }
+
             if ("c".equalsIgnoreCase(input)) {
                 ChatRoom room = createRoom(user);
                 if (room != null) enterRoom(user, room);
@@ -173,6 +181,10 @@ public class GitalkApplication {
             Notice latestNotice = noticeService.getNotices(room.getRoomId()).stream().findFirst().orElse(null);
             chatRoomView.printRoomActionMenu(room, isCreator, latestNotice);
             String input = readLine();
+
+            if (handleGlobalSlashCommand(user, input)) {
+                continue;
+            }
 
             switch (input == null ? "0" : input.trim()) {
                 case "1" -> { enterRoom(user, room); return; }
@@ -210,8 +222,21 @@ public class GitalkApplication {
 
     private static void enterRoom(Users user, ChatRoom room) {
         chatRoomView.printEntering(room);
-        String nickname = user.getNickname() != null ? user.getNickname() : user.getEmail();
+        String nickname = resolveNickname(user);
         chatRoomSession.enter(user.getUserId(), nickname, room.getRoomId(), room.getName());
+    }
+
+    private static boolean handleGlobalSlashCommand(Users user, String input) {
+        if (input == null || !input.startsWith("/")) {
+            return false;
+        }
+
+        chatRoomSession.handleOutsideRoomCommand(user.getUserId(), resolveNickname(user), input);
+        return true;
+    }
+
+    private static String resolveNickname(Users user) {
+        return user.getNickname() != null ? user.getNickname() : user.getEmail();
     }
 
     private static void inviteToRoom(Users inviter, ChatRoom room) {

--- a/src/main/java/com/gitalk/domain/chat/config/MongoConnectionManager.java
+++ b/src/main/java/com/gitalk/domain/chat/config/MongoConnectionManager.java
@@ -1,0 +1,74 @@
+package com.gitalk.domain.chat.config;
+
+/**
+ * MongoConnectionManager Description : 채팅 기능에서 공용으로 사용하는 MongoDB 연결과 컬렉션을 초기화하고 제공하는 설정 컴포넌트입니다.
+ * NOTE : config 계층의 싱글톤 클래스이며, repository 계층이 데이터베이스와 메시지 컬렉션을 가져올 때 사용합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 3:27
+ */
+import com.gitalk.domain.chat.exception.ChatRepositoryException;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+
+public class MongoConnectionManager {
+
+    private static MongoConnectionManager instance;
+
+    private final MongoClient mongoClient;
+    private final MongoDatabase database;
+    private final String collectionName;
+
+    private MongoConnectionManager() {
+        try {
+            String uri = getRequired("mongodb.uri");
+            String databaseName = getRequired("mongodb.database");
+            this.collectionName = getRequired("mongodb.collection");
+
+            ConnectionString connectionString = new ConnectionString(uri);
+            MongoClientSettings settings = MongoClientSettings.builder()
+                    .applyConnectionString(connectionString)
+                    .build();
+
+            this.mongoClient = MongoClients.create(settings);
+            this.database = mongoClient.getDatabase(databaseName);
+
+        } catch (Exception e) {
+            throw new ChatRepositoryException("MongoDB 연결 초기화 실패", e);
+        }
+    }
+
+    private String getRequired(String key) {
+        String value = com.gitalk.common.util.AppConfig.get(key);
+
+        if (value == null || value.isBlank()) {
+            throw new ChatRepositoryException("필수 설정값이 없습니다. key=" + key);
+        }
+
+        return value.trim();
+    }
+
+    public static synchronized MongoConnectionManager getInstance() {
+        if (instance == null) {
+            instance = new MongoConnectionManager();
+        }
+        return instance;
+    }
+
+    public MongoDatabase getDatabase() {
+        return database;
+    }
+
+    public MongoCollection<Document> getChatMessageCollection() {
+        return database.getCollection(collectionName);
+    }
+
+    public void close() {
+        mongoClient.close();
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/gitalk/domain/chat/domain/ChatMessage.java
@@ -1,0 +1,64 @@
+package com.gitalk.domain.chat.domain;
+
+/**
+ * ChatMessage Description : 저장된 채팅 메시지와 검색용 메타데이터를 함께 표현하는 domain 모델입니다.(Mongo DB 저장용)
+ * NOTE : domain 계층 객체이며, 키워드 검색과 문맥 조회를 위해 정규화된 본문 값을 함께 보관합니다.
+ * @author jki
+ * @since  04-09 (목) 오후 4:03
+ */
+import java.time.LocalDateTime;
+
+public class ChatMessage {
+
+    private final Long messageId;
+    private final Long roomId;
+    private final Long senderId;
+    private final String senderNickname;
+    private final String content;
+    private final String normalizedContent;
+    private final LocalDateTime createdAt;
+
+    public ChatMessage(Long messageId,
+                       Long roomId,
+                       Long senderId,
+                       String senderNickname,
+                       String content,
+                       String normalizedContent,
+                       LocalDateTime createdAt) {
+        this.messageId = messageId;
+        this.roomId = roomId;
+        this.senderId = senderId;
+        this.senderNickname = senderNickname;
+        this.content = content;
+        this.normalizedContent = normalizedContent;
+        this.createdAt = createdAt;
+    }
+
+    public Long getMessageId() {
+        return messageId;
+    }
+
+    public Long getRoomId() {
+        return roomId;
+    }
+
+    public Long getSenderId() {
+        return senderId;
+    }
+
+    public String getSenderNickname() {
+        return senderNickname;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getNormalizedContent() {
+        return normalizedContent;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/exception/ChatRepositoryException.java
+++ b/src/main/java/com/gitalk/domain/chat/exception/ChatRepositoryException.java
@@ -1,0 +1,19 @@
+package com.gitalk.domain.chat.exception;
+
+/**
+ * ChatRepositoryException Description : 채팅 저장소 처리와 영속화 과정에서 발생하는 예외를 표현하는 전용 예외 클래스입니다.
+ * NOTE : exception 계층의 런타임 예외이며, MongoDB 및 검색 저장소 관련 오류를 일관된 형태로 감싸는 데 사용합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 3:26
+ */
+public class ChatRepositoryException extends RuntimeException {
+
+    public ChatRepositoryException(String message) {
+        super(message);
+    }
+
+    public ChatRepositoryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/repository/MongoChatMessageRepository.java
+++ b/src/main/java/com/gitalk/domain/chat/repository/MongoChatMessageRepository.java
@@ -1,0 +1,175 @@
+package com.gitalk.domain.chat.repository;
+
+/**
+ * MongoChatMessageRepository Description : 채팅방 메시지를 MongoDB에 저장하고 조회하는 repository 구현체입니다.
+ * NOTE : repository 계층의 기본 MessageRepository 구현이며, 검색 성능을 위한 인덱스 생성도 함께 담당합니다.
+ * @author jki
+ * @since  04-09 (목) 오후 4:20
+ */
+import com.gitalk.domain.chat.config.MongoConnectionManager;
+import com.gitalk.domain.chat.domain.ChatMessage;
+import com.gitalk.domain.chat.domain.Message;
+import com.gitalk.domain.chat.exception.ChatRepositoryException;
+import com.gitalk.domain.chat.search.util.TextNormalizer;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Primary message repository used by the application runtime.
+ */
+public class MongoChatMessageRepository implements MessageRepository {
+
+    private static final AtomicLong MESSAGE_ID_SEQUENCE =
+            new AtomicLong(System.currentTimeMillis());
+
+    private final MongoCollection<Document> collection;
+
+    public MongoChatMessageRepository(MongoConnectionManager connectionManager) {
+        this.collection = connectionManager.getChatMessageCollection();
+    }
+
+    public void createIndexes() {
+        try {
+            collection.createIndex(
+                    Indexes.ascending("messageId"),
+                    new IndexOptions().unique(true)
+            );
+
+            collection.createIndex(
+                    Indexes.compoundIndex(
+                            Indexes.ascending("roomId"),
+                            Indexes.descending("createdAt")
+                    )
+            );
+
+            collection.createIndex(
+                    Indexes.compoundIndex(
+                            Indexes.ascending("roomId"),
+                            Indexes.ascending("normalizedContent"),
+                            Indexes.descending("createdAt")
+                    )
+            );
+        } catch (Exception e) {
+            throw new ChatRepositoryException("Mongo 인덱스 생성 실패", e);
+        }
+    }
+
+    @Override
+    public void save(Message message) {
+        validate(message);
+
+        try {
+            ChatMessage chatMessage = toChatMessage(message);
+
+            Document document = new Document()
+                    .append("messageId", chatMessage.getMessageId())
+                    .append("roomId", chatMessage.getRoomId())
+                    .append("senderId", chatMessage.getSenderId())
+                    .append("senderNickname", chatMessage.getSenderNickname())
+                    .append("content", chatMessage.getContent())
+                    .append("normalizedContent", chatMessage.getNormalizedContent())
+                    .append("createdAt", toDate(chatMessage.getCreatedAt()));
+
+            collection.insertOne(document);
+        } catch (Exception e) {
+            throw new ChatRepositoryException("Mongo 메시지 저장 실패", e);
+        }
+    }
+
+    @Override
+    public List<Message> findByRoomId(Long roomId) {
+        return findByRoomId(roomId, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public List<Message> findByRoomId(Long roomId, int limit) {
+        if (roomId == null) {
+            throw new ChatRepositoryException("roomId는 필수입니다.");
+        }
+        if (limit < 1) {
+            throw new ChatRepositoryException("limit는 1 이상이어야 합니다.");
+        }
+
+        try {
+            List<Message> result = new ArrayList<>();
+
+            for (Document doc : collection.find(Filters.eq("roomId", roomId))
+                    .sort(Sorts.descending("createdAt"))
+                    .limit(limit)) {
+
+                result.add(toMessage(doc));
+            }
+
+            return result;
+        } catch (Exception e) {
+            throw new ChatRepositoryException("Mongo 메시지 조회 실패", e);
+        }
+    }
+
+    private ChatMessage toChatMessage(Message message) {
+        return new ChatMessage(
+                generateMessageId(),
+                message.getRoomId(),
+                message.getUserId(),
+                message.getSenderNickname(),
+                message.getContent(),
+                TextNormalizer.normalize(message.getContent()),
+                message.getCreatedAt()
+        );
+    }
+
+    private Message toMessage(Document doc) {
+        return new Message(
+                doc.getLong("messageId"),
+                doc.getLong("senderId"),
+                doc.getLong("roomId"),
+                doc.getString("content"),
+                doc.getString("senderNickname"),
+                toLocalDateTime(doc.getDate("createdAt"))
+        );
+    }
+
+    private Long generateMessageId() {
+        return MESSAGE_ID_SEQUENCE.incrementAndGet();
+    }
+
+    private void validate(Message message) {
+        if (message == null) {
+            throw new ChatRepositoryException("message는 null일 수 없습니다.");
+        }
+        if (message.getUserId() == null) {
+            throw new ChatRepositoryException("userId는 필수입니다.");
+        }
+        if (message.getRoomId() == null) {
+            throw new ChatRepositoryException("roomId는 필수입니다.");
+        }
+        if (message.getSenderNickname() == null || message.getSenderNickname().isBlank()) {
+            throw new ChatRepositoryException("senderNickname은 필수입니다.");
+        }
+        if (message.getContent() == null || message.getContent().isBlank()) {
+            throw new ChatRepositoryException("content는 비어 있을 수 없습니다.");
+        }
+        if (message.getCreatedAt() == null) {
+            throw new ChatRepositoryException("createdAt은 필수입니다.");
+        }
+    }
+
+    private Date toDate(LocalDateTime localDateTime) {
+        return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    private LocalDateTime toLocalDateTime(Date date) {
+        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/repository/MongoSearchRepositoryImpl.java
+++ b/src/main/java/com/gitalk/domain/chat/repository/MongoSearchRepositoryImpl.java
@@ -1,0 +1,218 @@
+package com.gitalk.domain.chat.repository;
+
+/**
+ * MongoSearchRepositoryImpl Description : 메시지 검색, 페이징, 문맥 조회를 MongoDB 기준으로 처리하는 repository 구현체입니다.
+ * NOTE : repository 계층의 SearchRepository 구현이며, 정규화된 텍스트와 시간 조건을 이용해 검색과 문맥 조회를 수행합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 3:51
+ */
+import com.gitalk.domain.chat.config.MongoConnectionManager;
+import com.gitalk.domain.chat.domain.ChatMessage;
+import com.gitalk.domain.chat.search.domain.SearchContextResult;
+import com.gitalk.domain.chat.search.domain.SearchPageResult;
+import com.gitalk.domain.chat.exception.ChatRepositoryException;
+import com.gitalk.domain.chat.search.util.TextNormalizer;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Sorts;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class MongoSearchRepositoryImpl implements SearchRepository {
+
+    private final MongoCollection<Document> collection;
+
+    public MongoSearchRepositoryImpl(MongoConnectionManager connectionManager) {
+        this.collection = connectionManager.getChatMessageCollection();
+    }
+
+    @Override
+    public SearchPageResult<ChatMessage> searchByRoomId(Long roomId, int page, int pageSize) {
+        Bson filter = Filters.eq("roomId", roomId);
+        return search(filter, page, pageSize);
+    }
+
+    @Override
+    public SearchPageResult<ChatMessage> searchByRoomIds(List<Long> roomIds, int page, int pageSize) {
+        if (roomIds == null || roomIds.isEmpty()) {
+            return new SearchPageResult<>(Collections.emptyList(), page, pageSize, 0);
+        }
+        Bson filter = Filters.in("roomId", roomIds);
+        return search(filter, page, pageSize);
+    }
+
+    @Override
+    public SearchPageResult<ChatMessage> searchByKeyword(Long roomId, String keyword, int page, int pageSize) {
+        String normalizedKeyword = TextNormalizer.normalize(keyword);
+        Bson filter = Filters.and(
+                Filters.eq("roomId", roomId),
+                Filters.regex("normalizedContent", Pattern.quote(normalizedKeyword))
+        );
+        return search(filter, page, pageSize);
+    }
+
+    @Override
+    public SearchPageResult<ChatMessage> searchByKeyword(List<Long> roomIds, String keyword, int page, int pageSize) {
+        if (roomIds == null || roomIds.isEmpty()) {
+            return new SearchPageResult<>(Collections.emptyList(), page, pageSize, 0);
+        }
+
+        String normalizedKeyword = TextNormalizer.normalize(keyword);
+        Bson filter = Filters.and(
+                Filters.in("roomId", roomIds),
+                Filters.regex("normalizedContent", Pattern.quote(normalizedKeyword))
+        );
+        return search(filter, page, pageSize);
+    }
+
+    @Override
+    public Optional<ChatMessage> findByMessageId(Long messageId) {
+        if (messageId == null) {
+            throw new ChatRepositoryException("messageId는 필수입니다.");
+        }
+
+        try {
+            Document document = collection.find(Filters.eq("messageId", messageId)).first();
+            return Optional.ofNullable(document).map(this::toChatMessage);
+        } catch (Exception e) {
+            throw new ChatRepositoryException("messageId 조회 실패", e);
+        }
+    }
+
+    @Override
+    public List<ChatMessage> findContextBefore(Long roomId, LocalDateTime createdAt, int size) {
+        int safeSize = validateContextSize(size);
+
+        try {
+            Bson filter = Filters.and(
+                    Filters.eq("roomId", roomId),
+                    Filters.lt("createdAt", toDate(createdAt))
+            );
+
+            List<ChatMessage> result = new ArrayList<>();
+            FindIterable<Document> documents = collection.find(filter)
+                    .sort(Sorts.descending("createdAt"))
+                    .limit(safeSize);
+
+            for (Document document : documents) {
+                result.add(toChatMessage(document));
+            }
+
+            Collections.reverse(result);
+            return result;
+        } catch (Exception e) {
+            throw new ChatRepositoryException("이전 문맥 조회 실패", e);
+        }
+    }
+
+    @Override
+    public List<ChatMessage> findContextAfter(Long roomId, LocalDateTime createdAt, int size) {
+        int safeSize = validateContextSize(size);
+
+        try {
+            Bson filter = Filters.and(
+                    Filters.eq("roomId", roomId),
+                    Filters.gt("createdAt", toDate(createdAt))
+            );
+
+            List<ChatMessage> result = new ArrayList<>();
+            FindIterable<Document> documents = collection.find(filter)
+                    .sort(Sorts.ascending("createdAt"))
+                    .limit(safeSize);
+
+            for (Document document : documents) {
+                result.add(toChatMessage(document));
+            }
+
+            return result;
+        } catch (Exception e) {
+            throw new ChatRepositoryException("이후 문맥 조회 실패", e);
+        }
+    }
+
+    @Override
+    public SearchContextResult findMessageContext(Long messageId, int contextSize) {
+        int safeSize = validateContextSize(contextSize);
+
+        ChatMessage centerMessage = findByMessageId(messageId)
+                .orElseThrow(() -> new ChatRepositoryException("기준 메시지를 찾을 수 없습니다. messageId=" + messageId));
+
+        List<ChatMessage> beforeMessages =
+                findContextBefore(centerMessage.getRoomId(), centerMessage.getCreatedAt(), safeSize);
+
+        List<ChatMessage> afterMessages =
+                findContextAfter(centerMessage.getRoomId(), centerMessage.getCreatedAt(), safeSize);
+
+        return new SearchContextResult(centerMessage, beforeMessages, afterMessages);
+    }
+
+    private SearchPageResult<ChatMessage> search(Bson filter, int page, int pageSize) {
+        validatePage(page, pageSize);
+
+        try {
+            long totalCount = collection.countDocuments(filter);
+            int skip = (page - 1) * pageSize;
+
+            List<ChatMessage> items = new ArrayList<>();
+            FindIterable<Document> documents = collection.find(filter)
+                    .sort(Sorts.descending("createdAt"))
+                    .skip(skip)
+                    .limit(pageSize);
+
+            for (Document document : documents) {
+                items.add(toChatMessage(document));
+            }
+
+            return new SearchPageResult<>(items, page, pageSize, totalCount);
+        } catch (Exception e) {
+            throw new ChatRepositoryException("메시지 검색 실패", e);
+        }
+    }
+
+    private ChatMessage toChatMessage(Document doc) {
+        return new ChatMessage(
+                doc.getLong("messageId"),
+                doc.getLong("roomId"),
+                doc.getLong("senderId"),
+                doc.getString("senderNickname"),
+                doc.getString("content"),
+                doc.getString("normalizedContent"),
+                toLocalDateTime(doc.getDate("createdAt"))
+        );
+    }
+
+    private int validateContextSize(int size) {
+        if (size < 1 || size > 5) {
+            throw new ChatRepositoryException("context size는 1~5 범위여야 합니다.");
+        }
+        return size;
+    }
+
+    private void validatePage(int page, int pageSize) {
+        if (page < 1) {
+            throw new ChatRepositoryException("page는 1 이상이어야 합니다.");
+        }
+        if (pageSize < 1) {
+            throw new ChatRepositoryException("pageSize는 1 이상이어야 합니다.");
+        }
+    }
+
+    private Date toDate(LocalDateTime localDateTime) {
+        return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    private LocalDateTime toLocalDateTime(Date date) {
+        return date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/repository/SearchRepository.java
+++ b/src/main/java/com/gitalk/domain/chat/repository/SearchRepository.java
@@ -1,0 +1,35 @@
+package com.gitalk.domain.chat.repository;
+
+/**
+ * SearchRepository Description : 메시지 검색과 문맥 조회 기능을 정의하는 repository interface입니다.
+ * NOTE : repository 계층 인터페이스이며, service 계층이 저장소 종류에 의존하지 않도록 분리하는 역할을 합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 3:24
+ */
+import com.gitalk.domain.chat.domain.ChatMessage;
+import com.gitalk.domain.chat.search.domain.SearchContextResult;
+import com.gitalk.domain.chat.search.domain.SearchPageResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface SearchRepository {
+
+    SearchPageResult<ChatMessage> searchByRoomId(Long roomId, int page, int pageSize);
+
+    SearchPageResult<ChatMessage> searchByRoomIds(List<Long> roomIds, int page, int pageSize);
+
+    SearchPageResult<ChatMessage> searchByKeyword(Long roomId, String keyword, int page, int pageSize);
+
+    SearchPageResult<ChatMessage> searchByKeyword(List<Long> roomIds, String keyword, int page, int pageSize);
+
+    Optional<ChatMessage> findByMessageId(Long messageId);
+
+    List<ChatMessage> findContextBefore(Long roomId, LocalDateTime createdAt, int size);
+
+    List<ChatMessage> findContextAfter(Long roomId, LocalDateTime createdAt, int size);
+
+    SearchContextResult findMessageContext(Long messageId, int contextSize);
+}

--- a/src/main/java/com/gitalk/domain/chat/search/domain/SearchCommand.java
+++ b/src/main/java/com/gitalk/domain/chat/search/domain/SearchCommand.java
@@ -1,0 +1,60 @@
+package com.gitalk.domain.chat.search.domain;
+
+/**
+ * SearchCommand Description : /search 명령에서 해석된 옵션과 플래그를 담는 검색 명령 모델입니다.
+ * NOTE : search domain 요청 객체이며, SearchCommandParser가 생성하고 ChatSearchService가 사용합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 5:39
+ */
+public class SearchCommand {
+
+    private final Long roomId;
+    private final String keyword;
+    private final boolean help;
+    private final boolean share;
+    private final boolean view;
+    private final String shareId;
+
+    public SearchCommand(Long roomId,
+                         String keyword,
+                         boolean help,
+                         boolean share,
+                         boolean view,
+                         String shareId) {
+        this.roomId = roomId;
+        this.keyword = keyword;
+        this.help = help;
+        this.share = share;
+        this.view = view;
+        this.shareId = shareId;
+    }
+
+    public Long getRoomId() {
+        return roomId;
+    }
+
+    public String getKeyword() {
+        return keyword;
+    }
+
+    public boolean isHelp() {
+        return help;
+    }
+
+    public boolean isShare() {
+        return share;
+    }
+
+    public boolean isView() {
+        return view;
+    }
+
+    public String getShareId() {
+        return shareId;
+    }
+
+    public boolean hasKeyword() {
+        return keyword != null && !keyword.isBlank();
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/domain/SearchContextResult.java
+++ b/src/main/java/com/gitalk/domain/chat/search/domain/SearchContextResult.java
@@ -1,0 +1,40 @@
+package com.gitalk.domain.chat.search.domain;
+
+/**
+ * SearchContextResult Description : 검색에 일치한 메시지와 그 전후 문맥 메시지를 함께 묶어 표현하는 domain 결과 객체입니다.
+ * NOTE : domain 계층 DTO이며, 검색 결과 화면에서 앞뒤 문맥 블록을 구성할 때 사용합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 3:24
+ */
+import com.gitalk.domain.chat.domain.ChatMessage;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SearchContextResult {
+
+    private final ChatMessage centerMessage;
+    private final List<ChatMessage> beforeMessages;
+    private final List<ChatMessage> afterMessages;
+
+    public SearchContextResult(ChatMessage centerMessage,
+                               List<ChatMessage> beforeMessages,
+                               List<ChatMessage> afterMessages) {
+        this.centerMessage = centerMessage;
+        this.beforeMessages = beforeMessages == null ? Collections.emptyList() : beforeMessages;
+        this.afterMessages = afterMessages == null ? Collections.emptyList() : afterMessages;
+    }
+
+    public ChatMessage getCenterMessage() {
+        return centerMessage;
+    }
+
+    public List<ChatMessage> getBeforeMessages() {
+        return beforeMessages;
+    }
+
+    public List<ChatMessage> getAfterMessages() {
+        return afterMessages;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/domain/SearchExecutionContext.java
+++ b/src/main/java/com/gitalk/domain/chat/search/domain/SearchExecutionContext.java
@@ -1,0 +1,39 @@
+package com.gitalk.domain.chat.search.domain;
+
+/**
+ * SearchExecutionContext Description : 검색 실행 시 필요한 사용자 정보와 현재 방 상태를 담는 컨텍스트 모델입니다.
+ * NOTE : search domain DTO이며, 대상 방 결정과 검색 권한 검증에 필요한 문맥 정보를 제공합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 5:40
+ */
+public class SearchExecutionContext {
+
+    private final Long userId;
+    private final String nickname;
+    private final Long currentRoomId;
+    private final boolean joinedCurrentRoom;
+
+    public SearchExecutionContext(Long userId, String nickname, Long currentRoomId, boolean joinedCurrentRoom) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.currentRoomId = currentRoomId;
+        this.joinedCurrentRoom = joinedCurrentRoom;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public Long getCurrentRoomId() {
+        return currentRoomId;
+    }
+
+    public boolean isJoinedCurrentRoom() {
+        return joinedCurrentRoom;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/domain/SearchPageResult.java
+++ b/src/main/java/com/gitalk/domain/chat/search/domain/SearchPageResult.java
@@ -1,0 +1,49 @@
+package com.gitalk.domain.chat.search.domain;
+
+/**
+ * SearchPageResult Description : 채팅 메시지 검색 결과를 페이지 단위로 전달하기 위한 공통 domain 페이징 객체입니다.
+ * NOTE : domain 계층 DTO이며, 조회 항목 목록과 페이지 정보, 다음 페이지 존재 여부를 함께 담습니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 3:24
+ */
+
+import java.util.Collections;
+import java.util.List;
+
+public class SearchPageResult<T> {
+
+    private final List<T> items;
+    private final int page;
+    private final int pageSize;
+    private final long totalCount;
+    private final boolean hasNext;
+
+    public SearchPageResult(List<T> items, int page, int pageSize, long totalCount) {
+        this.items = items == null ? Collections.emptyList() : items;
+        this.page = page;
+        this.pageSize = pageSize;
+        this.totalCount = totalCount;
+        this.hasNext = ((long) page * pageSize) < totalCount;
+    }
+
+    public List<T> getItems() {
+        return items;
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public long getTotalCount() {
+        return totalCount;
+    }
+
+    public boolean isHasNext() {
+        return hasNext;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/domain/SearchSession.java
+++ b/src/main/java/com/gitalk/domain/chat/search/domain/SearchSession.java
@@ -1,0 +1,60 @@
+package com.gitalk.domain.chat.search.domain;
+
+/**
+ * SearchSession Description : 검색 메타데이터와 문맥이 포함된 결과를 함께 담는 검색 세션 모델입니다.
+ * NOTE : search domain 상태 객체이며, 사용자별 최근 검색 결과를 보관하고 공유/조회 흐름에서 재사용됩니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 5:40
+ */
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class SearchSession {
+
+    private final Long userId;
+    private final Long roomId;
+    private final String keyword;
+    private final List<SearchContextResult> contextResults;
+    private final LocalDateTime searchedAt;
+    private final boolean searchedInsideRoom;
+
+    public SearchSession(Long userId,
+                         Long roomId,
+                         String keyword,
+                         List<SearchContextResult> contextResults,
+                         LocalDateTime searchedAt,
+                         boolean searchedInsideRoom) {
+        this.userId = userId;
+        this.roomId = roomId;
+        this.keyword = keyword;
+        this.contextResults = contextResults;
+        this.searchedAt = searchedAt;
+        this.searchedInsideRoom = searchedInsideRoom;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Long getRoomId() {
+        return roomId;
+    }
+
+    public String getKeyword() {
+        return keyword;
+    }
+
+    public List<SearchContextResult> getContextResults() {
+        return contextResults;
+    }
+
+    public LocalDateTime getSearchedAt() {
+        return searchedAt;
+    }
+
+    public boolean isSearchedInsideRoom() {
+        return searchedInsideRoom;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/service/ChatSearchService.java
+++ b/src/main/java/com/gitalk/domain/chat/search/service/ChatSearchService.java
@@ -1,0 +1,101 @@
+package com.gitalk.domain.chat.search.service;
+
+/**
+ * ChatSearchService Description : 검색 명령을 검증하고 검색 세션 결과를 조합하는 채팅 검색 서비스입니다.
+ * NOTE : search/service 성격의 클래스이며, 방 접근 검증과 repository 조회, 문맥 결과 조합을 함께 조율합니다.
+ * 채팅 명령/권한/세션 조합까지 포함한 유스케이스 서비스
+ * @author jki
+ * @since 04-09 (목) 오후 5:41
+ */
+import com.gitalk.domain.chat.domain.ChatMessage;
+import com.gitalk.domain.chat.domain.ChatRoom;
+import com.gitalk.domain.chat.search.domain.SearchContextResult;
+import com.gitalk.domain.chat.search.domain.SearchPageResult;
+import com.gitalk.domain.chat.repository.SearchRepository;
+import com.gitalk.domain.chat.search.domain.SearchExecutionContext;
+import com.gitalk.domain.chat.search.domain.SearchSession;
+import com.gitalk.domain.chat.search.domain.SearchCommand;
+import com.gitalk.domain.chat.service.ChatRoomService;
+import com.gitalk.domain.chat.service.ChatService;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChatSearchService {
+
+    private final SearchRepository searchRepository;
+    private final ChatService chatService;
+    private final ChatRoomService chatRoomService;
+
+    public ChatSearchService(SearchRepository searchRepository,
+                             ChatService chatService,
+                             ChatRoomService chatRoomService) {
+        this.searchRepository = searchRepository;
+        this.chatService = chatService;
+        this.chatRoomService = chatRoomService;
+    }
+
+    public SearchSession search(SearchCommand command, SearchExecutionContext context) {
+        validateSearchPermission(command, context);
+
+        Long targetRoomId = resolveTargetRoomId(command, context);
+        boolean insideRoomSearch = context.isJoinedCurrentRoom() && targetRoomId.equals(context.getCurrentRoomId());
+
+        SearchPageResult<ChatMessage> pageResult =
+                searchRepository.searchByKeyword(targetRoomId, command.getKeyword(), 1, 20);
+
+        List<SearchContextResult> contextBlocks = new ArrayList<>();
+        for (ChatMessage message : pageResult.getItems()) {
+            contextBlocks.add(searchRepository.findMessageContext(message.getMessageId(), 3));
+        }
+
+        return new SearchSession(
+                context.getUserId(),
+                targetRoomId,
+                command.getKeyword(),
+                contextBlocks,
+                LocalDateTime.now(),
+                insideRoomSearch
+        );
+    }
+
+    private void validateSearchPermission(SearchCommand command, SearchExecutionContext context) {
+        if (command.isShare()) {
+            return;
+        }
+
+        if (!command.hasKeyword()) {
+            throw new IllegalArgumentException("검색어를 입력하세요.");
+        }
+
+        if (command.getRoomId() == null && !context.isJoinedCurrentRoom()) {
+            throw new IllegalArgumentException("채팅방 밖에서는 /search -r [roomNo] [keyword] 형식만 가능합니다.");
+        }
+
+        if (command.getRoomId() != null) {
+            resolveRequestedRoomId(command.getRoomId(), context.getUserId());
+            return;
+        }
+
+        if (!context.isJoinedCurrentRoom()) {
+            throw new IllegalArgumentException("현재 참여 중인 방이 없습니다.");
+        }
+    }
+
+    private Long resolveTargetRoomId(SearchCommand command, SearchExecutionContext context) {
+        if (command.getRoomId() != null) {
+            return resolveRequestedRoomId(command.getRoomId(), context.getUserId());
+        }
+        return context.getCurrentRoomId();
+    }
+
+    private Long resolveRequestedRoomId(Long roomNumber, Long userId) {
+        List<ChatRoom> myRooms = chatRoomService.getMyRooms(userId);
+        int index = Math.toIntExact(roomNumber) - 1;
+        if (index < 0 || index >= myRooms.size()) {
+            throw new IllegalArgumentException("Invalid room number.");
+        }
+        return myRooms.get(index).getRoomId();
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/service/SearchSessionManager.java
+++ b/src/main/java/com/gitalk/domain/chat/search/service/SearchSessionManager.java
@@ -1,0 +1,54 @@
+package com.gitalk.domain.chat.search.service;
+
+/**
+ * SearchSessionManager Description : 사용자 검색 세션과 공유용 세션 스냅샷을 관리하는 매니저입니다.
+ * NOTE : search 지원 컴포넌트이며, 최근 검색 결과를 사용자 ID 또는 공유 ID에 매핑해 보관합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 5:40
+ */
+import com.gitalk.domain.chat.search.domain.SearchSession;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SearchSessionManager {
+
+    private final Map<Long, SearchSession> userSessions = new ConcurrentHashMap<>();
+    private final Map<String, SearchSession> sharedSessions = new ConcurrentHashMap<>();
+
+    public void save(SearchSession session) {
+        userSessions.put(session.getUserId(), session);
+    }
+
+    public SearchSession get(Long userId) {
+        return userSessions.get(userId);
+    }
+
+    public void remove(Long userId) {
+        userSessions.remove(userId);
+    }
+
+    public String share(SearchSession session) {
+        String shareId = "SR-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        sharedSessions.put(shareId, session);
+        return shareId;
+    }
+
+    public SearchSession getShared(String shareId) {
+        return sharedSessions.get(shareId);
+    }
+
+    public void saveShared(String shareId, SearchSession session) {
+        if (shareId == null || shareId.isBlank() || session == null) {
+            return;
+        }
+        sharedSessions.put(shareId, session);
+    }
+
+    public void clear() {
+        userSessions.clear();
+        sharedSessions.clear();
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/service/SearchShareService.java
+++ b/src/main/java/com/gitalk/domain/chat/search/service/SearchShareService.java
@@ -1,0 +1,21 @@
+package com.gitalk.domain.chat.search.service;
+
+import com.gitalk.domain.chat.search.domain.SearchSession;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SearchShareService {
+    private final Map<String, SearchSession> sharedSessions = new ConcurrentHashMap<>();
+
+    public SearchShareService() {
+    }
+    public String shareSession(SearchSession session) {
+        String shareId = "SR-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        sharedSessions.put(shareId, session);
+        return shareId;
+    }
+    public SearchSession getSharedSession(String shareId) {
+        return sharedSessions.get(shareId);
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/util/SearchCommandParser.java
+++ b/src/main/java/com/gitalk/domain/chat/search/util/SearchCommandParser.java
@@ -1,0 +1,128 @@
+package com.gitalk.domain.chat.search.util;
+
+/**
+ * SearchCommandParser Description : 사용자가 입력한 /search 문자열을 SearchCommand로 해석하는 파서입니다.
+ * NOTE : search 유틸리티 성격의 헬퍼이며, 도움말, 방 선택, 공유, 조회 옵션 파싱을 담당합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 5:39
+ */
+import com.gitalk.domain.chat.search.domain.SearchCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SearchCommandParser {
+
+    private SearchCommandParser() {
+    }
+
+    public static SearchCommand parse(String raw) {
+        List<String> tokens = tokenize(raw);
+
+        Long roomId = null;
+        boolean help = false;
+        boolean share = false;
+        boolean view = false;
+        String shareId = null;
+        List<String> keywordParts = new ArrayList<>();
+
+        for (int i = 0; i < tokens.size(); i++) {
+            String token = tokens.get(i);
+            String lower = token.toLowerCase();
+
+            switch (lower) {
+                case "-h", "--help", "help" -> help = true;
+
+                case "-s", "--share" -> share = true;
+
+                case "-v", "--view" -> {
+                    view = true;
+                    if (i + 1 >= tokens.size()) {
+                        throw new IllegalArgumentException("공유 ID를 입력하세요. 예: /search --view SR-478C6BAB");
+                    }
+                    shareId = tokens.get(++i);
+                }
+
+                case "-r" -> {
+                    if (i + 1 >= tokens.size()) {
+                        throw new IllegalArgumentException("room 번호를 입력하세요.");
+                    }
+                    try {
+                        roomId = Long.parseLong(tokens.get(++i));
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("room 번호는 숫자여야 합니다.");
+                    }
+                }
+
+                default -> keywordParts.add(token);
+            }
+        }
+
+        String keyword = String.join(" ", keywordParts).trim();
+
+        if (help) {
+            return new SearchCommand(null, null, true, false, false, null);
+        }
+
+        if (share) {
+            return new SearchCommand(null, null, false, true, false, null);
+        }
+
+        if (view) {
+            return new SearchCommand(null, null, false, false, true, shareId);
+        }
+
+        if (keyword.isBlank()) {
+            throw new IllegalArgumentException("검색어를 입력하세요.");
+        }
+
+        return new SearchCommand(
+                roomId,
+                keyword,
+                false,
+                false,
+                false,
+                null
+        );
+    }
+
+    private static List<String> tokenize(String input) {
+        List<String> result = new ArrayList<>();
+        if (input == null || input.isBlank()) {
+            return result;
+        }
+
+        StringBuilder current = new StringBuilder();
+        boolean inQuote = false;
+
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+
+            if (ch == '"') {
+                inQuote = !inQuote;
+                continue;
+            }
+
+            if (Character.isWhitespace(ch) && !inQuote) {
+                if (current.length() > 0) {
+                    result.add(current.toString());
+                    current.setLength(0);
+                }
+                continue;
+            }
+
+            current.append(ch);
+        }
+
+        if (inQuote) {
+            throw new IllegalArgumentException("따옴표가 닫히지 않았습니다.");
+        }
+
+        if (current.length() > 0) {
+            result.add(current.toString());
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/util/SearchSessionCodec.java
+++ b/src/main/java/com/gitalk/domain/chat/search/util/SearchSessionCodec.java
@@ -1,0 +1,138 @@
+package com.gitalk.domain.chat.search.util;
+import com.gitalk.domain.chat.domain.ChatMessage;
+import com.gitalk.domain.chat.search.domain.SearchContextResult;
+import com.gitalk.domain.chat.search.domain.SearchSession;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+public final class SearchSessionCodec {
+    private static final Gson GSON = new GsonBuilder().create();
+    private SearchSessionCodec() {
+    }
+    public static String encode(SearchSession session) {
+        return Base64.getEncoder()
+                .encodeToString(GSON.toJson(toPayload(session)).getBytes(StandardCharsets.UTF_8));
+    }
+    public static SearchSession decode(String encoded) {
+        String json = new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
+        SessionPayload payload = GSON.fromJson(json, SessionPayload.class);
+        return fromPayload(payload);
+    }
+    private static SessionPayload toPayload(SearchSession session) {
+        SessionPayload payload = new SessionPayload();
+        payload.userId = session.getUserId();
+        payload.roomId = session.getRoomId();
+        payload.keyword = session.getKeyword();
+        payload.searchedAt = session.getSearchedAt() != null ? session.getSearchedAt().toString() : null;
+        payload.searchedInsideRoom = session.isSearchedInsideRoom();
+        payload.contextResults = new ArrayList<>();
+        for (SearchContextResult result : session.getContextResults()) {
+            ContextPayload contextPayload = new ContextPayload();
+            contextPayload.centerMessage = toPayload(result.getCenterMessage());
+            contextPayload.beforeMessages = toPayloadMessages(result.getBeforeMessages());
+            contextPayload.afterMessages = toPayloadMessages(result.getAfterMessages());
+            payload.contextResults.add(contextPayload);
+        }
+        return payload;
+    }
+    private static SearchSession fromPayload(SessionPayload payload) {
+        List<SearchContextResult> contextResults = new ArrayList<>();
+        if (payload != null && payload.contextResults != null) {
+            for (ContextPayload contextPayload : payload.contextResults) {
+                contextResults.add(new SearchContextResult(
+                        fromPayload(contextPayload.centerMessage),
+                        fromPayloadMessages(contextPayload.beforeMessages),
+                        fromPayloadMessages(contextPayload.afterMessages)
+                ));
+            }
+        }
+        LocalDateTime searchedAt = payload != null && payload.searchedAt != null
+                ? LocalDateTime.parse(payload.searchedAt)
+                : LocalDateTime.now();
+        return new SearchSession(
+                payload != null ? payload.userId : null,
+                payload != null ? payload.roomId : null,
+                payload != null ? payload.keyword : "",
+                contextResults,
+                searchedAt,
+                payload != null && payload.searchedInsideRoom
+        );
+    }
+    private static List<MessagePayload> toPayloadMessages(List<ChatMessage> messages) {
+        List<MessagePayload> payloads = new ArrayList<>();
+        if (messages == null) {
+            return payloads;
+        }
+        for (ChatMessage message : messages) {
+            payloads.add(toPayload(message));
+        }
+        return payloads;
+    }
+    private static List<ChatMessage> fromPayloadMessages(List<MessagePayload> payloads) {
+        List<ChatMessage> messages = new ArrayList<>();
+        if (payloads == null) {
+            return messages;
+        }
+        for (MessagePayload payload : payloads) {
+            messages.add(fromPayload(payload));
+        }
+        return messages;
+    }
+    private static MessagePayload toPayload(ChatMessage message) {
+        if (message == null) {
+            return null;
+        }
+        MessagePayload payload = new MessagePayload();
+        payload.messageId = message.getMessageId();
+        payload.roomId = message.getRoomId();
+        payload.senderId = message.getSenderId();
+        payload.senderNickname = message.getSenderNickname();
+        payload.content = message.getContent();
+        payload.normalizedContent = message.getNormalizedContent();
+        payload.createdAt = message.getCreatedAt() != null ? message.getCreatedAt().toString() : null;
+        return payload;
+    }
+    private static ChatMessage fromPayload(MessagePayload payload) {
+        if (payload == null) {
+            return null;
+        }
+        LocalDateTime createdAt = payload.createdAt != null
+                ? LocalDateTime.parse(payload.createdAt)
+                : LocalDateTime.now();
+        return new ChatMessage(
+                payload.messageId,
+                payload.roomId,
+                payload.senderId,
+                payload.senderNickname,
+                payload.content,
+                payload.normalizedContent,
+                createdAt
+        );
+    }
+    private static final class SessionPayload {
+        private Long userId;
+        private Long roomId;
+        private String keyword;
+        private List<ContextPayload> contextResults;
+        private String searchedAt;
+        private boolean searchedInsideRoom;
+    }
+    private static final class ContextPayload {
+        private MessagePayload centerMessage;
+        private List<MessagePayload> beforeMessages;
+        private List<MessagePayload> afterMessages;
+    }
+    private static final class MessagePayload {
+        private Long messageId;
+        private Long roomId;
+        private Long senderId;
+        private String senderNickname;
+        private String content;
+        private String normalizedContent;
+        private String createdAt;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/util/SearchShareCodec.java
+++ b/src/main/java/com/gitalk/domain/chat/search/util/SearchShareCodec.java
@@ -1,0 +1,225 @@
+package com.gitalk.domain.chat.search.util;
+
+import com.gitalk.domain.chat.domain.ChatMessage;
+import com.gitalk.domain.chat.search.domain.SearchContextResult;
+import com.gitalk.domain.chat.search.domain.SearchSession;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class SearchShareCodec {
+
+    private static final Gson GSON = new GsonBuilder().create();
+    private static final Pattern PAYLOAD_PATTERN =
+            Pattern.compile("\\s*\\[SEARCHSHARE([A-Za-z0-9+/=]+)]\\s*$");
+
+    private SearchShareCodec() {
+    }
+
+    public static String appendPayload(String visibleMessage, String shareId, SearchSession session) {
+        ShareEnvelope envelope = new ShareEnvelope();
+        envelope.shareId = shareId;
+        envelope.session = toPayload(session);
+
+        String encoded = Base64.getEncoder()
+                .encodeToString(GSON.toJson(envelope).getBytes(StandardCharsets.UTF_8));
+
+        return visibleMessage + " [SEARCHSHARE" + encoded + "]";
+    }
+
+    public static ParsedSharedMessage parseMessage(String content) {
+        if (content == null) {
+            return new ParsedSharedMessage("", null, null);
+        }
+
+        Matcher matcher = PAYLOAD_PATTERN.matcher(content);
+        if (!matcher.find()) {
+            return new ParsedSharedMessage(content, null, null);
+        }
+
+        String visibleMessage = content.substring(0, matcher.start()).trim();
+        String encoded = matcher.group(1);
+
+        try {
+            String json = new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
+            ShareEnvelope envelope = GSON.fromJson(json, ShareEnvelope.class);
+            if (envelope == null || envelope.shareId == null || envelope.session == null) {
+                return new ParsedSharedMessage(visibleMessage, null, null);
+            }
+            return new ParsedSharedMessage(
+                    visibleMessage,
+                    envelope.shareId,
+                    fromPayload(envelope.session)
+            );
+        } catch (Exception e) {
+            return new ParsedSharedMessage(visibleMessage, null, null);
+        }
+    }
+
+    public static final class ParsedSharedMessage {
+        private final String visibleMessage;
+        private final String shareId;
+        private final SearchSession session;
+
+        public ParsedSharedMessage(String visibleMessage, String shareId, SearchSession session) {
+            this.visibleMessage = visibleMessage;
+            this.shareId = shareId;
+            this.session = session;
+        }
+
+        public String getVisibleMessage() {
+            return visibleMessage;
+        }
+
+        public String getShareId() {
+            return shareId;
+        }
+
+        public SearchSession getSession() {
+            return session;
+        }
+
+        public boolean hasSharedSession() {
+            return shareId != null && session != null;
+        }
+    }
+
+    private static SessionPayload toPayload(SearchSession session) {
+        SessionPayload payload = new SessionPayload();
+        payload.userId = session.getUserId();
+        payload.roomId = session.getRoomId();
+        payload.keyword = session.getKeyword();
+        payload.searchedAt = session.getSearchedAt() != null ? session.getSearchedAt().toString() : null;
+        payload.searchedInsideRoom = session.isSearchedInsideRoom();
+        payload.contextResults = new ArrayList<>();
+
+        for (SearchContextResult result : session.getContextResults()) {
+            ContextPayload contextPayload = new ContextPayload();
+            contextPayload.centerMessage = toPayload(result.getCenterMessage());
+            contextPayload.beforeMessages = toPayloadMessages(result.getBeforeMessages());
+            contextPayload.afterMessages = toPayloadMessages(result.getAfterMessages());
+            payload.contextResults.add(contextPayload);
+        }
+
+        return payload;
+    }
+
+    private static SearchSession fromPayload(SessionPayload payload) {
+        List<SearchContextResult> contextResults = new ArrayList<>();
+        if (payload.contextResults != null) {
+            for (ContextPayload contextPayload : payload.contextResults) {
+                contextResults.add(new SearchContextResult(
+                        fromPayload(contextPayload.centerMessage),
+                        fromPayloadMessages(contextPayload.beforeMessages),
+                        fromPayloadMessages(contextPayload.afterMessages)
+                ));
+            }
+        }
+
+        LocalDateTime searchedAt = payload.searchedAt != null
+                ? LocalDateTime.parse(payload.searchedAt)
+                : LocalDateTime.now();
+
+        return new SearchSession(
+                payload.userId,
+                payload.roomId,
+                payload.keyword,
+                contextResults,
+                searchedAt,
+                payload.searchedInsideRoom
+        );
+    }
+
+    private static List<MessagePayload> toPayloadMessages(List<ChatMessage> messages) {
+        List<MessagePayload> payloads = new ArrayList<>();
+        if (messages == null) {
+            return payloads;
+        }
+        for (ChatMessage message : messages) {
+            payloads.add(toPayload(message));
+        }
+        return payloads;
+    }
+
+    private static List<ChatMessage> fromPayloadMessages(List<MessagePayload> payloads) {
+        List<ChatMessage> messages = new ArrayList<>();
+        if (payloads == null) {
+            return messages;
+        }
+        for (MessagePayload payload : payloads) {
+            messages.add(fromPayload(payload));
+        }
+        return messages;
+    }
+
+    private static MessagePayload toPayload(ChatMessage message) {
+        if (message == null) {
+            return null;
+        }
+        MessagePayload payload = new MessagePayload();
+        payload.messageId = message.getMessageId();
+        payload.roomId = message.getRoomId();
+        payload.senderId = message.getSenderId();
+        payload.senderNickname = message.getSenderNickname();
+        payload.content = message.getContent();
+        payload.normalizedContent = message.getNormalizedContent();
+        payload.createdAt = message.getCreatedAt() != null ? message.getCreatedAt().toString() : null;
+        return payload;
+    }
+
+    private static ChatMessage fromPayload(MessagePayload payload) {
+        if (payload == null) {
+            return null;
+        }
+        LocalDateTime createdAt = payload.createdAt != null
+                ? LocalDateTime.parse(payload.createdAt)
+                : LocalDateTime.now();
+
+        return new ChatMessage(
+                payload.messageId,
+                payload.roomId,
+                payload.senderId,
+                payload.senderNickname,
+                payload.content,
+                payload.normalizedContent,
+                createdAt
+        );
+    }
+
+    private static final class ShareEnvelope {
+        private String shareId;
+        private SessionPayload session;
+    }
+
+    private static final class SessionPayload {
+        private Long userId;
+        private Long roomId;
+        private String keyword;
+        private List<ContextPayload> contextResults;
+        private String searchedAt;
+        private boolean searchedInsideRoom;
+    }
+
+    private static final class ContextPayload {
+        private MessagePayload centerMessage;
+        private List<MessagePayload> beforeMessages;
+        private List<MessagePayload> afterMessages;
+    }
+
+    private static final class MessagePayload {
+        private Long messageId;
+        private Long roomId;
+        private Long senderId;
+        private String senderNickname;
+        private String content;
+        private String normalizedContent;
+        private String createdAt;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/util/SearchWindowLauncher.java
+++ b/src/main/java/com/gitalk/domain/chat/search/util/SearchWindowLauncher.java
@@ -1,0 +1,67 @@
+package com.gitalk.domain.chat.search.util;
+
+/**
+ * SearchWindowLauncher Description : 검색 결과를 별도 Windows 콘솔 창으로 띄워주는 실행 유틸리티입니다.
+ * NOTE : search/view 보조 유틸리티이며, UTF-8 결과 텍스트를 임시 파일로 저장한 뒤 cmd 창을 실행합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 6:26
+ */
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class SearchWindowLauncher {
+
+    private static final Charset CMD_CHARSET = Charset.forName("MS949");
+
+    public void open(String title, String content) {
+        try {
+            Path textFile = Files.createTempFile("gitalk-search-", ".txt");
+            Files.writeString(textFile, content, StandardCharsets.UTF_8);
+
+            Path cmdFile = Files.createTempFile("gitalk-search-", ".cmd");
+
+            String script = buildScript(title, textFile);
+            Files.writeString(cmdFile, script, CMD_CHARSET);
+
+            new ProcessBuilder(
+                    "cmd", "/c",
+                    "start", "\"\"",
+                    "cmd", "/k",
+                    "call", "\"" + cmdFile.toAbsolutePath() + "\""
+            ).start();
+
+        } catch (IOException e) {
+            throw new IllegalStateException("검색 결과 창을 열 수 없습니다: " + e.getMessage(), e);
+        }
+    }
+
+    private String buildScript(String title, Path textFile) {
+        String safeTitle = sanitize(title);
+        String safePath = textFile.toAbsolutePath().toString();
+
+        return "@echo off\r\n"
+                + "title " + safeTitle + "\r\n"
+                + "chcp 65001 > nul\r\n"
+                + "cls\r\n"
+                + "echo ========================================\r\n"
+                + "echo " + safeTitle + "\r\n"
+                + "echo ========================================\r\n"
+                + "echo.\r\n"
+                + "type \"" + safePath + "\"\r\n"
+                + "echo.\r\n"
+                + "echo ----------------------------------------\r\n"
+                + "echo Press any key to close...\r\n"
+                + "pause > nul\r\n";
+    }
+
+    private String sanitize(String text) {
+        if (text == null || text.isBlank()) {
+            return "Search Result";
+        }
+        return text.replace("\"", "").replace("&", "^&").trim();
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/search/util/TextNormalizer.java
+++ b/src/main/java/com/gitalk/domain/chat/search/util/TextNormalizer.java
@@ -1,0 +1,29 @@
+package com.gitalk.domain.chat.search.util;
+
+/**
+ * TextNormalizer Description : 키워드 검색이 안정적으로 동작하도록 문자열을 정규화하는 유틸리티입니다.
+ * NOTE : util 계층 헬퍼이며, NFKC 정규화와 trim, 소문자 변환, 공백 정리를 수행합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 3:25
+ */
+import java.text.Normalizer;
+import java.util.Locale;
+
+public final class TextNormalizer {
+
+    private TextNormalizer() {
+    }
+
+    public static String normalize(String text) {
+        if (text == null) {
+            return "";
+        }
+
+        String normalized = Normalizer.normalize(text, Normalizer.Form.NFKC);
+        normalized = normalized.trim().toLowerCase(Locale.ROOT);
+        normalized = normalized.replaceAll("\\s+", " ");
+
+        return normalized;
+    }
+}

--- a/src/main/java/com/gitalk/domain/chat/service/Protocol.java
+++ b/src/main/java/com/gitalk/domain/chat/service/Protocol.java
@@ -31,7 +31,11 @@ public class Protocol {
     public static final String QUIT         = "QUIT";
     public static final String SERVER       = "SERVER";
     public static final String ASCII_ART    = "ASCII_ART";  // 이미지 → ASCII 아트 패킷
-
+    public static final String SEARCH_SHARE = "SEARCH_SHARE";
+    public static final String SEARCH_SHARED = "SEARCH_SHARED";
+    public static final String SEARCH_VIEW = "SEARCH_VIEW";
+    public static final String SEARCH_VIEW_RESULT = "SEARCH_VIEW_RESULT";
+    public static final String SEARCH_ERROR = "SEARCH_ERROR";
     static final String SEP = ":";
 
     // ── 클라이언트 → 서버 빌더 ──────────────────────────────────────────────
@@ -86,6 +90,21 @@ public class Protocol {
     public static String buildBotPacket(String content) {
         return BOT + SEP + content;
     }
+    public static String buildSearchSharePacket(String encodedSession) {
+        return SEARCH_SHARE + SEP + encodedSession;
+    }
+    public static String buildSearchSharedPacket(String shareId) {
+        return SEARCH_SHARED + SEP + shareId;
+    }
+    public static String buildSearchViewPacket(String shareId) {
+        return SEARCH_VIEW + SEP + shareId;
+    }
+    public static String buildSearchViewResultPacket(String shareId, String encodedSession) {
+        return SEARCH_VIEW_RESULT + SEP + shareId + SEP + encodedSession;
+    }
+    public static String buildSearchErrorPacket(String message) {
+        return SEARCH_ERROR + SEP + message;
+    }
 
     /**
      * ASCII 아트 패킷: ASCII_ART:sender:filename:base64(art)
@@ -116,5 +135,33 @@ public class Protocol {
     public static String typeOf(String raw) {
         int idx = raw.indexOf(SEP);
         return idx == -1 ? raw : raw.substring(0, idx);
+    }
+    public static String extractClientMessageContent(String raw) {
+        return extractBody(raw, MSG);
+    }
+    public static String extractBotContent(String raw) {
+        return extractBody(raw, BOT);
+    }
+    public static String extractSearchSharePayload(String raw) {
+        return extractBody(raw, SEARCH_SHARE);
+    }
+    public static String extractSearchViewShareId(String raw) {
+        return extractBody(raw, SEARCH_VIEW);
+    }
+    public static String extractSearchSharedShareId(String raw) {
+        return extractBody(raw, SEARCH_SHARED);
+    }
+    public static String extractSearchErrorMessage(String raw) {
+        return extractBody(raw, SEARCH_ERROR);
+    }
+    private static String extractBody(String raw, String type) {
+        if (raw == null) {
+            return "";
+        }
+        String prefix = type + SEP;
+        if (!raw.startsWith(prefix)) {
+            return "";
+        }
+        return raw.substring(prefix.length());
     }
 }

--- a/src/main/java/com/gitalk/domain/chat/session/ChatRoomSession.java
+++ b/src/main/java/com/gitalk/domain/chat/session/ChatRoomSession.java
@@ -226,9 +226,33 @@ public class ChatRoomSession {
             socketOut = null;
             lineReader = null;
             terminal = null;
+            currentRoomId = null;
+            currentUserId = null;
             currentNickname = null;
             Spinner.setSuppressed(false);
         }
+    }
+
+    public void handleOutsideRoomCommand(Long userId, String nickname, String rawCommand) {
+        String command = sanitize(rawCommand);
+        if (command.isEmpty()) {
+            return;
+        }
+
+        if (command.startsWith("/")) {
+            command = command.substring(1).trim();
+        }
+
+        String[] parts = command.split("\\s+", 2);
+        String main = parts[0].toLowerCase();
+        String arg = parts.length > 1 ? parts[1].trim() : "";
+
+        if (!"search".equals(main)) {
+            System.out.println(" 채팅방 밖에서는 /search 명령만 사용할 수 있습니다.");
+            return;
+        }
+
+        executeSearchCommand(arg, nickname, userId, null, false);
     }
 
     // ── 출력 (JLine printAbove 위임) ────────────────────────────────────────
@@ -618,8 +642,15 @@ public class ChatRoomSession {
     }
 
     private void cmdSearch(String arg, String nickname) {
+        executeSearchCommand(arg, nickname, currentUserId, currentRoomId, currentRoomId != null);
+    }
+
+    private void executeSearchCommand(String arg,
+                                      String nickname,
+                                      Long userId,
+                                      Long roomId,
+                                      boolean joinedCurrentRoom) {
         try {
-            boolean joinedCurrentRoom = currentRoomId != null;
 
             SearchCommand command = SearchCommandParser.parse(arg);
 
@@ -629,13 +660,13 @@ public class ChatRoomSession {
             }
 
             if (command.isShare()) {
-                SearchSession session = searchSessionManager.get(currentUserId);
+                SearchSession session = searchSessionManager.get(userId);
                 if (session == null) {
                     printToScroll(DIM + " 최근 검색 내역이 없습니다." + RESET);
                     return;
                 }
 
-                if (!joinedCurrentRoom || currentRoomId == null) {
+                if (!joinedCurrentRoom || roomId == null) {
                     printToScroll(DIM + " 채팅방 안에서만 검색 결과를 공유할 수 있습니다." + RESET);
                     return;
                 }
@@ -666,9 +697,9 @@ public class ChatRoomSession {
                 return;
             }
             SearchExecutionContext context = new SearchExecutionContext(
-                    currentUserId,
+                    userId,
                     nickname,
-                    currentRoomId,
+                    roomId,
                     joinedCurrentRoom
             );
 

--- a/src/main/java/com/gitalk/domain/chat/session/ChatRoomSession.java
+++ b/src/main/java/com/gitalk/domain/chat/session/ChatRoomSession.java
@@ -7,7 +7,6 @@ import com.gitalk.domain.chat.search.domain.SearchExecutionContext;
 import com.gitalk.domain.chat.search.domain.SearchSession;
 import com.gitalk.domain.chat.search.util.SearchCommandParser;
 import com.gitalk.domain.chat.search.util.SearchShareCodec;
-import com.gitalk.domain.chat.search.util.SearchWindowLauncher;
 import com.gitalk.domain.chat.search.service.ChatSearchService;
 import com.gitalk.domain.chat.search.domain.SearchCommand;
 import com.gitalk.domain.chat.search.service.SearchSessionManager;
@@ -92,8 +91,6 @@ public class ChatRoomSession {
     private final ChatSearchService chatSearchService;
     private final SearchSessionManager searchSessionManager;
     private final SearchView searchView;
-    private final SearchWindowLauncher searchWindowLauncher = new SearchWindowLauncher();
-
     // 세션 컨텍스트 (enter() 동안만 유효)
     private LineReader lineReader;
     private Terminal   terminal;
@@ -252,7 +249,43 @@ public class ChatRoomSession {
             return;
         }
 
-        executeSearchCommand(arg, nickname, userId, null, false);
+        runOutsideRoomCommandWithViewer(() ->
+                executeSearchCommand(arg, nickname, userId, null, false));
+    }
+
+    private void runOutsideRoomCommandWithViewer(Runnable action) {
+        if (terminal != null && lineReader != null) {
+            action.run();
+            return;
+        }
+
+        Terminal previousTerminal = terminal;
+        LineReader previousLineReader = lineReader;
+
+        try (Terminal tempTerminal = TerminalBuilder.builder()
+                .system(true)
+                .name("gitalk-search")
+                .encoding(StandardCharsets.UTF_8)
+                .build()) {
+
+            LineReader tempReader = LineReaderBuilder.builder()
+                    .terminal(tempTerminal)
+                    .option(LineReader.Option.DISABLE_EVENT_EXPANSION, true)
+                    .option(LineReader.Option.HISTORY_BEEP, false)
+                    .option(LineReader.Option.ERASE_LINE_ON_FINISH, true)
+                    .option(LineReader.Option.AUTO_FRESH_LINE, true)
+                    .build();
+
+            terminal = tempTerminal;
+            lineReader = tempReader;
+            action.run();
+        } catch (IOException e) {
+            System.out.println(" 검색 화면을 여는 중 오류가 발생했습니다: " + e.getMessage());
+            action.run();
+        } finally {
+            lineReader = previousLineReader;
+            terminal = previousTerminal;
+        }
     }
 
     // ── 출력 (JLine printAbove 위임) ────────────────────────────────────────
@@ -474,6 +507,63 @@ public class ChatRoomSession {
         }
     }
 
+    private void showSearchResult(String title, String content) {
+        String safeTitle = (title == null || title.isBlank()) ? "결과" : title.trim();
+        String body = content == null ? "" : content;
+
+        if (terminal == null || lineReader == null) {
+            printToScroll(BOLD + " ===== " + safeTitle + " =====" + RESET);
+            for (String line : body.split("\n", -1)) {
+                printToScroll(line);
+            }
+            printToScroll(BOLD + " =========================" + RESET);
+            return;
+        }
+
+        viewerActive = true;
+        try {
+            terminal.puts(Capability.enter_ca_mode);
+            terminal.puts(Capability.clear_screen);
+            terminal.flush();
+
+            PrintWriter w = terminal.writer();
+            int width = Math.min(80, Math.max(20, terminal.getWidth()));
+            String div = "=".repeat(width);
+            w.println();
+            w.println(BOLD + " " + safeTitle + RESET);
+            w.println(div);
+            w.print(body);
+            if (!body.endsWith("\n")) {
+                w.println();
+            }
+            w.println(div);
+            w.flush();
+
+            try {
+                while (true) {
+                    String line = lineReader.readLine(DIM + " q+Enter (또는 Enter) 로 채팅방으로 돌아가기 > " + RESET);
+                    if (line == null) break;
+                    String t = sanitize(line);
+                    if (t.isEmpty() || "q".equalsIgnoreCase(t)) break;
+                }
+            } catch (UserInterruptException | EndOfFileException ignored) {
+            }
+        } finally {
+            terminal.puts(Capability.exit_ca_mode);
+            terminal.flush();
+
+            synchronized (this) {
+                if (lineReader != null) {
+                    for (String msg : viewerBuffer) {
+                        lineReader.printAbove(msg);
+                    }
+                }
+                viewerBuffer.clear();
+                viewerActive = false;
+            }
+        }
+    }
+
     private static String detectContentType(File file) {
         String name = file.getName().toLowerCase();
         if (name.endsWith(".png"))  return "image/png";
@@ -655,7 +745,7 @@ public class ChatRoomSession {
             SearchCommand command = SearchCommandParser.parse(arg);
 
             if (command.isHelp()) {
-                searchWindowLauncher.open("Search Help", searchView.helpText());
+                showSearchResult("Search Help", searchView.helpText());
                 return;
             }
 
@@ -692,8 +782,8 @@ public class ChatRoomSession {
                 }
 
                 String rendered = searchView.render(sharedSession);
-                searchWindowLauncher.open("Shared Search - " + command.getShareId(), rendered);
-                printToScroll(GREEN + " 공유 검색 결과 창을 열었습니다." + RESET);
+                showSearchResult("Shared Search - " + command.getShareId(), rendered);
+                printToScroll(GREEN + " 공유 검색 결과를 화면에 표시했습니다." + RESET);
                 return;
             }
             SearchExecutionContext context = new SearchExecutionContext(
@@ -707,9 +797,9 @@ public class ChatRoomSession {
             searchSessionManager.save(session);
 
             String rendered = searchView.render(session);
-            searchWindowLauncher.open("Search Result - " + session.getKeyword(), rendered);
+            showSearchResult("Search Result - " + session.getKeyword(), rendered);
 
-            printToScroll(GREEN + " 검색 결과를 새 창으로 열었습니다." + RESET);
+            printToScroll(GREEN + " 검색 결과를 화면에 표시했습니다." + RESET);
 
         } catch (Exception e) {
             printToScroll(DIM + " 검색 처리 중 오류: " + e.getMessage() + RESET);

--- a/src/main/java/com/gitalk/domain/chat/session/ChatRoomSession.java
+++ b/src/main/java/com/gitalk/domain/chat/session/ChatRoomSession.java
@@ -3,10 +3,19 @@ package com.gitalk.domain.chat.session;
 import com.gitalk.common.api.ImageAsciiHttpServer;
 import com.gitalk.common.util.Screen;
 import com.gitalk.common.util.Spinner;
+import com.gitalk.domain.chat.search.domain.SearchExecutionContext;
+import com.gitalk.domain.chat.search.domain.SearchSession;
+import com.gitalk.domain.chat.search.util.SearchCommandParser;
+import com.gitalk.domain.chat.search.util.SearchShareCodec;
+import com.gitalk.domain.chat.search.util.SearchWindowLauncher;
+import com.gitalk.domain.chat.search.service.ChatSearchService;
+import com.gitalk.domain.chat.search.domain.SearchCommand;
+import com.gitalk.domain.chat.search.service.SearchSessionManager;
 import com.gitalk.domain.chat.service.ChatRoomService;
 import com.gitalk.domain.chat.service.NoticeService;
 import com.gitalk.domain.chat.service.Protocol;
 import com.gitalk.domain.chat.domain.Notice;
+import com.gitalk.domain.chat.view.SearchView;
 import com.gitalk.domain.chatbot.model.NewsItem;
 import com.gitalk.domain.chatbot.model.TrendingRepo;
 import com.gitalk.domain.chatbot.model.WebhookEvent;
@@ -80,6 +89,11 @@ public class ChatRoomSession {
     private final UserService      userService;
     private final NoticeService    noticeService;
 
+    private final ChatSearchService chatSearchService;
+    private final SearchSessionManager searchSessionManager;
+    private final SearchView searchView;
+    private final SearchWindowLauncher searchWindowLauncher = new SearchWindowLauncher();
+
     // 세션 컨텍스트 (enter() 동안만 유효)
     private LineReader lineReader;
     private Terminal   terminal;
@@ -101,13 +115,19 @@ public class ChatRoomSession {
                            WebhookService webhookService,
                            ChatRoomService chatRoomService,
                            UserService userService,
-                           NoticeService noticeService) {
+                           NoticeService noticeService,
+                           ChatSearchService chatSearchService,
+                           SearchSessionManager searchSessionManager,
+                           SearchView searchView) {
         this.trendingService = trendingService;
         this.newsService     = newsService;
         this.webhookService  = webhookService;
         this.chatRoomService = chatRoomService;
         this.userService     = userService;
         this.noticeService   = noticeService;
+        this.chatSearchService   = chatSearchService;
+        this.searchSessionManager   = searchSessionManager;
+        this.searchView   = searchView;
     }
 
     // ── 진입점 ───────────────────────────────────────────────────────────────
@@ -248,6 +268,7 @@ public class ChatRoomSession {
             case "invite"  -> cmdInvite(arg);
             case "notice"  -> cmdNotice(arg);
             case "image"   -> cmdImage(arg);
+            case "search"  -> cmdSearch(arg, nickname);
             case "help"    -> cmdHelp();
             default        -> printToScroll(DIM + " 알 수 없는 명령어. /help 로 목록 확인" + RESET);
         }
@@ -596,6 +617,74 @@ public class ChatRoomSession {
         }
     }
 
+    private void cmdSearch(String arg, String nickname) {
+        try {
+            boolean joinedCurrentRoom = currentRoomId != null;
+
+            SearchCommand command = SearchCommandParser.parse(arg);
+
+            if (command.isHelp()) {
+                searchWindowLauncher.open("Search Help", searchView.helpText());
+                return;
+            }
+
+            if (command.isShare()) {
+                SearchSession session = searchSessionManager.get(currentUserId);
+                if (session == null) {
+                    printToScroll(DIM + " 최근 검색 내역이 없습니다." + RESET);
+                    return;
+                }
+
+                if (!joinedCurrentRoom || currentRoomId == null) {
+                    printToScroll(DIM + " 채팅방 안에서만 검색 결과를 공유할 수 있습니다." + RESET);
+                    return;
+                }
+
+                String shareId = searchSessionManager.share(session);
+
+                String shareMessage = "[검색공유] " + nickname
+                        + "님이 검색 결과를 공유했습니다. /search --view " + shareId;
+                String packetMessage = SearchShareCodec.appendPayload(shareMessage, shareId, session);
+
+                // 서버로 일반 채팅 메시지처럼 전송
+                socketOut.println(Protocol.buildMsgPacket(packetMessage));
+
+                // 내 화면에도 바로 보이게 출력
+                printToScroll(formatOwn(nickname, shareMessage));
+                return;
+            }
+            if (command.isView()) {
+                SearchSession sharedSession = searchSessionManager.getShared(command.getShareId());
+                if (sharedSession == null) {
+                    printToScroll(DIM + " 공유된 검색 결과를 찾을 수 없습니다: " + command.getShareId() + RESET);
+                    return;
+                }
+
+                String rendered = searchView.render(sharedSession);
+                searchWindowLauncher.open("Shared Search - " + command.getShareId(), rendered);
+                printToScroll(GREEN + " 공유 검색 결과 창을 열었습니다." + RESET);
+                return;
+            }
+            SearchExecutionContext context = new SearchExecutionContext(
+                    currentUserId,
+                    nickname,
+                    currentRoomId,
+                    joinedCurrentRoom
+            );
+
+            SearchSession session = chatSearchService.search(command, context);
+            searchSessionManager.save(session);
+
+            String rendered = searchView.render(session);
+            searchWindowLauncher.open("Search Result - " + session.getKeyword(), rendered);
+
+            printToScroll(GREEN + " 검색 결과를 새 창으로 열었습니다." + RESET);
+
+        } catch (Exception e) {
+            printToScroll(DIM + " 검색 처리 중 오류: " + e.getMessage() + RESET);
+        }
+    }
+
     private void cmdHelp() {
         printToScroll(BOLD + " ─── 명령어 ───" + RESET);
         printToScroll(" /notice             공지 목록 보기");
@@ -608,6 +697,10 @@ public class ChatRoomSession {
         printToScroll(" /webhook list       웹훅 이벤트 목록");
         printToScroll(" /image              이미지 업로드 → ASCII 아트 변환 후 방에 공유");
         printToScroll(" /image <N>.view     수신한 N번 이미지 ASCII 아트 보기");
+        printToScroll(" /search <키워드>    현재 방 메시지 검색");
+        printToScroll(" /search -r <방번호> <키워드>  특정 방 검색");
+        printToScroll(" /search -s         최근 검색 결과 공유");
+        printToScroll(" /search -v <shareId>  공유된 검색 결과 보기");
         printToScroll(" /help               이 목록 표시");
         printToScroll(" /quit               채팅방 퇴장");
     }
@@ -618,9 +711,16 @@ public class ChatRoomSession {
         String[] parts = Protocol.parse(packet);
         String time = LocalTime.now().format(TIME_FMT);
         return switch (parts[0]) {
-            case Protocol.MSG -> parts.length >= 3
-                    ? " " + DIM + time + RESET + "  " + BOLD + "[" + parts[1] + "]" + RESET + "  " + parts[2]
-                    : "";
+            case Protocol.MSG -> {
+                if (parts.length < 3) {
+                    yield "";
+                }
+                SearchShareCodec.ParsedSharedMessage parsed = SearchShareCodec.parseMessage(parts[2]);
+                if (parsed.hasSharedSession()) {
+                    searchSessionManager.saveShared(parsed.getShareId(), parsed.getSession());
+                }
+                yield " " + DIM + time + RESET + "  " + BOLD + "[" + parts[1] + "]" + RESET + "  " + parsed.getVisibleMessage();
+            }
             case Protocol.BOT -> parts.length >= 2
                     ? " " + DIM + time + RESET + "  " + YELLOW + BOLD + "[봇]" + RESET + "  " + parts[1]
                     : "";

--- a/src/main/java/com/gitalk/domain/chat/socket/ChatServer.java
+++ b/src/main/java/com/gitalk/domain/chat/socket/ChatServer.java
@@ -1,9 +1,10 @@
 package com.gitalk.domain.chat.socket;
 
 import com.gitalk.common.api.ImageAsciiHttpServer;
-import com.gitalk.domain.chat.repository.InMemoryChatRepository;
-import com.gitalk.domain.chat.repository.MessageRepositoryImpl;
+import com.gitalk.domain.chat.config.MongoConnectionManager;
+import com.gitalk.domain.chat.repository.*;
 import com.gitalk.domain.chat.service.ChatService;
+import com.gitalk.domain.chat.search.service.SearchShareService;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -15,10 +16,12 @@ public class ChatServer {
 
     private final int port;
     private final ChatService chatService;
+    private final SearchShareService searchShareService;
 
-    public ChatServer(int port, ChatService chatService) {
+    public ChatServer(int port, ChatService chatService, SearchShareService searchShareService) {
         this.port = port;
         this.chatService = chatService;
+        this.searchShareService = searchShareService;
     }
 
     public void start() throws IOException {
@@ -34,15 +37,24 @@ public class ChatServer {
             while (true) {
                 Socket socket = serverSocket.accept();
                 System.out.println("[연결] 클라이언트: " + socket.getInetAddress().getHostAddress());
-                ClientHandler handler = new ClientHandler(socket, chatService);
+                ClientHandler handler = new ClientHandler(socket, chatService, searchShareService);
                 handler.start();
             }
         }
     }
 
     public static void main(String[] args) throws IOException {
+        MongoConnectionManager connectionManager = MongoConnectionManager.getInstance();
+
+        MongoChatMessageRepository messageRepository = new MongoChatMessageRepository(connectionManager);
+        messageRepository.createIndexes();
+
         // DB 연동: MessageRepositoryImpl / 로컬 테스트: InMemoryChatRepository
-        ChatService chatService = new ChatService(new MessageRepositoryImpl());
-        new ChatServer(PORT, chatService).start();
+        // Primary runtime storage uses Mongo; swap in another MessageRepository
+        // implementation only for local fallback or storage migration work.
+        ChatService chatService = new ChatService(messageRepository);
+        SearchShareService searchShareService = new SearchShareService();
+        Runtime.getRuntime().addShutdownHook(new Thread(connectionManager::close));
+        new ChatServer(PORT, chatService, searchShareService).start();
     }
 }

--- a/src/main/java/com/gitalk/domain/chat/socket/ClientHandler.java
+++ b/src/main/java/com/gitalk/domain/chat/socket/ClientHandler.java
@@ -1,9 +1,12 @@
 package com.gitalk.domain.chat.socket;
 
 import com.gitalk.domain.chat.domain.Message;
+import com.gitalk.domain.chat.search.domain.SearchSession;
+import com.gitalk.domain.chat.search.util.SearchSessionCodec;
 import com.gitalk.domain.chat.service.ChatService;
 import com.gitalk.domain.chat.service.MessageSender;
 import com.gitalk.domain.chat.service.Protocol;
+import com.gitalk.domain.chat.search.service.SearchShareService;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -21,15 +24,17 @@ public class ClientHandler extends Thread implements MessageSender {
 
     private final Socket socket;
     private final ChatService chatService;
+    private final SearchShareService searchShareService;
     private BufferedReader in;
     private PrintWriter out;
     private String nickname;
     private Long userId;  // 로그인 연동 후 설정
     private Long roomId;  // JOIN 패킷에서 설정
 
-    public ClientHandler(Socket socket, ChatService chatService) {
+    public ClientHandler(Socket socket, ChatService chatService, SearchShareService searchShareService) {
         this.socket = socket;
         this.chatService = chatService;
+        this.searchShareService = searchShareService;
     }
 
     @Override
@@ -90,19 +95,61 @@ public class ClientHandler extends Thread implements MessageSender {
             if (Protocol.QUIT.equals(type)) break;
 
             if (Protocol.MSG.equals(type)) {
-                String[] parts = Protocol.parse(packet);
-                if (parts.length >= 2 && !parts[1].isBlank()) {
-                    Message msg = new Message(userId, nickname, parts[1], roomId);
+                String content = Protocol.extractClientMessageContent(packet);
+                if (!content.isBlank()) {
+                    Message msg = new Message(userId, nickname, content, roomId);
                     chatService.broadcast(msg, this);
-                    System.out.println("[채팅 roomId=" + roomId + "] " + nickname + ": " + parts[1]);
+                    System.out.println("[채팅 roomId=" + roomId + "] " + nickname + ": " + content);
                 }
             } else if (Protocol.BOT.equals(type)) {
-                String[] parts = Protocol.parse(packet);
-                if (parts.length >= 2) {
-                    chatService.broadcastBot(roomId, Protocol.buildBotPacket(parts[1]), this);
+                String content = Protocol.extractBotContent(packet);
+                if (!content.isBlank()) {
+                    chatService.broadcastBot(roomId, Protocol.buildBotPacket(content), this);
                 }
+            } else if (Protocol.SEARCH_SHARE.equals(type)) {
+                handleSearchShare(packet);
+            } else if (Protocol.SEARCH_VIEW.equals(type)) {
+                handleSearchView(packet);
             }
         }
+    }
+
+    private void handleSearchShare(String packet) {
+        try {
+            String encodedSession = Protocol.extractSearchSharePayload(packet);
+            if (encodedSession.isBlank()) {
+                sendRaw(Protocol.buildSearchErrorPacket("공유할 검색 결과가 없습니다."));
+                return;
+            }
+
+            SearchSession session = SearchSessionCodec.decode(encodedSession);
+            String shareId = searchShareService.shareSession(session);
+            sendRaw(Protocol.buildSearchSharedPacket(shareId));
+
+            String shareMessage = "[검색공유] " + nickname
+                    + "님이 검색 결과를 공유했습니다. /search --view " + shareId;
+            Message msg = new Message(userId, nickname, shareMessage, roomId);
+            chatService.broadcast(msg, this);
+        } catch (Exception e) {
+            sendRaw(Protocol.buildSearchErrorPacket("검색 결과 공유 실패: " + e.getMessage()));
+        }
+    }
+
+    private void handleSearchView(String packet) {
+        String shareId = Protocol.extractSearchViewShareId(packet);
+        if (shareId.isBlank()) {
+            sendRaw(Protocol.buildSearchErrorPacket("공유 ID를 입력하세요."));
+            return;
+        }
+
+        SearchSession session = searchShareService.getSharedSession(shareId);
+        if (session == null) {
+            sendRaw(Protocol.buildSearchErrorPacket("공유된 검색 결과를 찾을 수 없습니다: " + shareId));
+            return;
+        }
+
+        String encodedSession = SearchSessionCodec.encode(session);
+        sendRaw(Protocol.buildSearchViewResultPacket(shareId, encodedSession));
     }
 
     private void disconnect() {

--- a/src/main/java/com/gitalk/domain/chat/view/SearchView.java
+++ b/src/main/java/com/gitalk/domain/chat/view/SearchView.java
@@ -1,0 +1,78 @@
+package com.gitalk.domain.chat.view;
+
+/**
+ * SearchView Description : 검색 결과와 명령 도움말을 콘솔 출력용 문자열로 렌더링하는 view 클래스입니다.
+ * NOTE : view 계층 포맷터이며, SearchSession 데이터를 사용자에게 보여줄 형태로 가공합니다.
+ *
+ * @author jki
+ * @since 04-09 (목) 오후 3:25
+ */
+
+import com.gitalk.domain.chat.domain.ChatMessage;
+import com.gitalk.domain.chat.search.domain.SearchContextResult;
+import com.gitalk.domain.chat.search.domain.SearchSession;
+
+import java.util.List;
+
+public class SearchView {
+
+    public String render(SearchSession session) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("========== SEARCH RESULT ==========\n");
+        sb.append("roomId: ").append(session.getRoomId()).append("\n");
+        sb.append("keyword: ").append(session.getKeyword()).append("\n");
+        sb.append("searchedAt: ").append(session.getSearchedAt()).append("\n");
+        sb.append("\n");
+
+        List<SearchContextResult> results = session.getContextResults();
+        if (results.isEmpty()) {
+            sb.append("검색 결과가 없습니다.\n");
+            sb.append("==================================\n");
+            return sb.toString();
+        }
+
+        for (int i = 0; i < results.size(); i++) {
+            SearchContextResult block = results.get(i);
+            sb.append("----- result #").append(i + 1).append(" -----\n");
+
+            for (ChatMessage before : block.getBeforeMessages()) {
+                sb.append(format(before)).append("\n");
+            }
+
+            sb.append("[MATCH] ").append(format(block.getCenterMessage())).append("\n");
+
+            for (ChatMessage after : block.getAfterMessages()) {
+                sb.append(format(after)).append("\n");
+            }
+
+            sb.append("\n");
+        }
+
+        sb.append("==================================\n");
+        return sb.toString();
+    }
+
+    public String helpText() {
+        return String.join("\n",
+                "/search -h",
+                "/search --help",
+                "/search [keyword]",
+                "/search -r [roomNo] [keyword]",
+                "/search -s",
+                "/search --share",
+                "/search -v [shareId]",
+                "/search --view [shareId]"
+        );
+    }
+
+    private String format(ChatMessage message) {
+        return String.format(
+                "[%s] %s: %s (id=%d)",
+                message.getCreatedAt(),
+                message.getSenderNickname(),
+                message.getContent(),
+                message.getMessageId()
+        );
+    }
+}

--- a/src/main/java/com/gitalk/domain/oauth/github/exception/GithubAuthorizationPendingException.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/exception/GithubAuthorizationPendingException.java
@@ -1,8 +1,8 @@
 package com.gitalk.domain.oauth.github.exception;
 
 /**
- * GithubAuthorizationPendingException Description :
- * NOTE :
+ * GithubAuthorizationPendingException Description : GitHub Device Flow 인증이 아직 완료되지 않았음을 나타내는 예외 클래스입니다.
+ * NOTE : oauth exception 계층 예외이며, 재시도 가능한 대기 상태를 일반 실패와 구분할 때 사용합니다.
  *
  * @author jki
  * @since 04-08 (수) 오후 5:41

--- a/src/main/java/com/gitalk/domain/oauth/github/model/GithubDeviceCode.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/model/GithubDeviceCode.java
@@ -1,8 +1,8 @@
 package com.gitalk.domain.oauth.github.model;
 
 /**
- * GithubDeviceCode Description :
- * NOTE :
+ * GithubDeviceCode Description : GitHub Device Flow 인증에 필요한 코드와 polling 정보를 담는 모델입니다.
+ * NOTE : model 계층 DTO이며, GitHub 기기 인증 시작 단계의 응답 데이터를 표현합니다.
  *
  * @author jki
  * @since 04-08 (수) 오후 4:56

--- a/src/main/java/com/gitalk/domain/oauth/github/model/GithubUserInfo.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/model/GithubUserInfo.java
@@ -1,8 +1,8 @@
 package com.gitalk.domain.oauth.github.model;
 
 /**
- * GithubUserInfo Description :
- * NOTE :
+ * GithubUserInfo Description : 인증된 GitHub 사용자 프로필 정보를 담는 모델입니다.
+ * NOTE : model 계층 DTO이며, 기존 계정 연동이나 GitHub 회원 등록 과정에서 사용됩니다.
  *
  * @author jki
  * @since 04-08 (수) 오후 4:56

--- a/src/main/java/com/gitalk/domain/oauth/github/service/GithubAuthService.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/service/GithubAuthService.java
@@ -7,8 +7,8 @@ import com.gitalk.domain.user.repository.UserRepository;
 import java.util.Optional;
 
 /**
- * GithubAuthService Description :
- * NOTE :
+ * GithubAuthService Description : GitHub 로그인, 계정 연동, 회원 등록 흐름을 조율하는 인증 서비스입니다.
+ * NOTE : service 계층 클래스이며, GithubOauthClient와 UserRepository를 연결해 GitHub 인증 절차를 처리합니다.
  *
  * @author jki
  * @since 04-08 (수) 오후 4:57

--- a/src/main/java/com/gitalk/domain/oauth/github/service/GithubOauthClient.java
+++ b/src/main/java/com/gitalk/domain/oauth/github/service/GithubOauthClient.java
@@ -17,8 +17,8 @@ import com.gitalk.domain.oauth.github.model.GithubDeviceCode;
 import com.gitalk.domain.oauth.github.model.GithubUserInfo;
 
 /**
- * GithubOauthClient Description :
- * NOTE :
+ * GithubOauthClient Description : GitHub OAuth 및 사용자 API를 HTTP로 호출하는 클라이언트입니다.
+ * NOTE : 외부 연동용 service 성격의 클래스이며, 토큰 polling, 사용자 정보 조회, API 오류 처리를 담당합니다.
  *
  * @author jki
  * @since 04-08 (수) 오후 4:58

--- a/src/main/java/com/gitalk/domain/user/service/UserService.java
+++ b/src/main/java/com/gitalk/domain/user/service/UserService.java
@@ -7,8 +7,8 @@ import java.security.MessageDigest;
 import java.util.Optional;
 
 /**
- * UserService Description :
- * NOTE :
+ * UserService Description : 일반 회원 가입, 비밀번호 암호화, 로그인 검증을 처리하는 사용자 서비스입니다.
+ * NOTE : service 계층 클래스이며, LOCAL 계정 정책을 관리하고 실제 저장은 UserRepository에 위임합니다.
  *
  * @author jki
  * @since 04-07 (화) 오후 2:47

--- a/src/main/java/com/gitalk/domain/user/view/JoinAndLoginView.java
+++ b/src/main/java/com/gitalk/domain/user/view/JoinAndLoginView.java
@@ -1,8 +1,8 @@
 package com.gitalk.domain.user.view;
 
 /**
- * JoinAndLoginView Description :
- * NOTE :
+ * JoinAndLoginView Description : 콘솔 기반 회원 가입, 일반 로그인, GitHub 로그인 화면 흐름을 담당하는 view 클래스입니다.
+ * NOTE : view 계층 클래스이며, 사용자 입력과 출력은 처리하고 실제 비즈니스 로직은 service 계층에 위임합니다.
  *
  * @author jki
  * @since 04-07 (화) 오후 3:00


### PR DESCRIPTION
## 관련 이슈
> 이 PR과 관련된 이슈 번호를 작성해주세요.
- closes #26

## 작업 내용
> 어떤 변경을 했는지 간략하게 설명해주세요.
채팅방 메시지 검색 기능 신규 구현
키워드 검색, 특정 방 검색, 검색 결과 문맥 조회, 검색 결과 공유/재조회 흐름까지 함께 추가

## 변경 사항
- [x] 기능 구현
- [x] 기능 수정
- [ ] 문서 작업
- [ ] 테스트

## 구현 내용 상세
> 주요 변경 내용을 설명해주세요.
- `/search` 명령 기반 채팅 검색 기능 구현함
- 현재 방 검색, 특정 방 번호 기준 검색 흐름 추가함
- 검색 결과를 단순 목록이 아니라 매칭 메시지 기준 전후 문맥까지 함께 조회하도록 구성함
- 검색 결과를 `SearchSession`으로 관리하고, 공유 ID를 통해 다시 조회할 수 있는 흐름 추가함
- 검색 결과 출력용 `SearchView`, 별도 창 출력용 `SearchWindowLauncher`, 공유 데이터 인코딩/디코딩 처리 로직 추가함
- MongoDB 기반 메시지 저장/검색 구조 연결해서 검색 및 문맥 조회 가능하도록 구현함
- 검색 관련 클래스 역할이 드러나도록 service/domain/repository/view 구조 정리하고 주석 보강함
- 구현 과정에서 발생한 UTF-8 BOM 문제와 JLine 출력 예외 함께 정리함
- docker-compose.yml 수정 -> MongoDB 컨테이너 추가
- compile.bat 파일 수정

## 테스트 결과
> 어떻게 테스트했는지 작성해주세요.
- [ ] 로컬 실행 확인
- [ ] 기존 기능 정상 동작 확인

## 리뷰어에게 (선택)
> 리뷰어가 집중해서 봐야 할 부분이나 전달 사항을 작성해주세요.
- 검색 기능이 MongoDB 저장 구조 기준으로 동작해서 메시지 저장 시점과 검색 시점 데이터 형태가 맞는지 확인
- `/search` 명령 처리 흐름과 공유 ID 기반 재조회 흐름이 현재 콘솔 UX에 맞는지 
- `ChatSearchService`와 `SearchShareService` 역할 분리가 현재 구조에서 적절한지

## 스크린샷 (선택)
> 변경 전/후 화면이 있다면 첨부해주세요.
