### PR TITLE
Feat/#27 오픈 채팅 도입 + 채팅방 목록 레이아웃 정비

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -23,12 +23,13 @@ CREATE TABLE IF NOT EXISTS users (
 -- OPEN 타입은 같은 이름으로 중복 생성 불가 (TEAM은 자유)
 -- 함수형 유니크 인덱스: TEAM 행은 NULL로 평가되어 중복 허용
 CREATE TABLE IF NOT EXISTS chat_rooms (
-                                          roomid     BIGINT AUTO_INCREMENT PRIMARY KEY,
-                                          name       VARCHAR(255) NOT NULL,
-    type       ENUM('TEAM', 'OPEN') NOT NULL,
-    team_url   VARCHAR(255),
-    creator_id BIGINT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                          roomid      BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                          name        VARCHAR(255) NOT NULL,
+    type        ENUM('TEAM', 'OPEN') NOT NULL,
+    team_url    VARCHAR(255),
+    description VARCHAR(500),                  -- OPEN 방 토픽 설명 (TEAM은 NULL)
+    creator_id  BIGINT,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_open_room_name ((CASE WHEN type = 'OPEN' THEN name END)),
     FOREIGN KEY (creator_id) REFERENCES users(userid) ON DELETE SET NULL
     );

--- a/src/main/java/com/gitalk/GitalkApplication.java
+++ b/src/main/java/com/gitalk/GitalkApplication.java
@@ -144,7 +144,12 @@ public class GitalkApplication {
     private static void runChatRoom(Users user) {
         while (true) {
             mainView.clearScreen();
-            List<ChatRoom> rooms = chatRoomService.getMyRooms(user.getUserId());
+            // 화면 표시 / 번호 매핑이 일치하도록 TEAM 먼저, OPEN 나중으로 정렬해서 view에 넘김
+            List<ChatRoom> rooms = chatRoomService.getMyRooms(user.getUserId()).stream()
+                    .sorted(java.util.Comparator
+                            .comparingInt((ChatRoom r) -> "TEAM".equals(r.getType()) ? 0 : 1)
+                            .thenComparing(ChatRoom::getRoomId))
+                    .toList();
             Map<Long, Integer> memberCounts = rooms.stream()
                     .collect(Collectors.toMap(
                             ChatRoom::getRoomId,
@@ -159,9 +164,14 @@ public class GitalkApplication {
             }
 
             if ("c".equalsIgnoreCase(input)) {
-                ChatRoom room = createRoom(user);
+                ChatRoom room = createTeamRoom(user);
                 if (room != null) enterRoom(user, room);
                 continue; // 방 목록 새로고침
+            }
+
+            if ("o".equalsIgnoreCase(input)) {
+                runOpenChat(user);
+                continue; // 오픈 채팅 둘러보기 종료 후 내 방 목록으로 복귀
             }
 
             try {
@@ -169,6 +179,102 @@ public class GitalkApplication {
                 if (choice < 1 || choice > rooms.size()) continue;
                 handleRoomAction(user, rooms.get(choice - 1));
             } catch (NumberFormatException ignored) {}
+        }
+    }
+
+    // ── 오픈 채팅 둘러보기 ──────────────────────────────────────────────────
+
+    private static final int OPEN_CHAT_LIMIT = 20;
+
+    private static void runOpenChat(Users user) {
+        List<ChatRoom> rooms = chatRoomService.listPopularOpenRooms(OPEN_CHAT_LIMIT);
+        String header = "오픈 채팅 — 인기";
+
+        while (true) {
+            mainView.clearScreen();
+            Map<Long, Integer> memberCounts = rooms.stream()
+                    .collect(Collectors.toMap(
+                            ChatRoom::getRoomId,
+                            r -> chatRoomService.getMemberCount(r.getRoomId())));
+            chatRoomView.printOpenRoomList(header, rooms, memberCounts);
+
+            String input = readLine();
+            if (input == null || input.equals("0")) return;
+
+            if ("c".equalsIgnoreCase(input)) {
+                ChatRoom created = createOpenChat(user);
+                if (created != null) enterRoom(user, created);
+                rooms = chatRoomService.listPopularOpenRooms(OPEN_CHAT_LIMIT);
+                header = "오픈 채팅 — 인기";
+                continue;
+            }
+
+            if ("s".equalsIgnoreCase(input)) {
+                String keyword = promptSearchKeyword();
+                if (keyword == null || keyword.isBlank()) continue;
+                rooms = chatRoomService.searchOpenRooms(keyword, OPEN_CHAT_LIMIT);
+                header = "검색 결과: \"" + keyword + "\"";
+                if (rooms.isEmpty()) {
+                    chatRoomView.printOpenRoomNoResult(keyword);
+                    chatRoomView.pressEnter();
+                    readLine();
+                    rooms = chatRoomService.listPopularOpenRooms(OPEN_CHAT_LIMIT);
+                    header = "오픈 채팅 — 인기";
+                }
+                continue;
+            }
+
+            try {
+                int choice = Integer.parseInt(input);
+                if (choice < 1 || choice > rooms.size()) continue;
+                ChatRoom selected = rooms.get(choice - 1);
+                // 자동 가입 후 입장
+                try {
+                    chatRoomService.joinOpenRoom(selected.getRoomId(), user.getUserId());
+                } catch (Exception e) {
+                    System.out.println(" 입장 실패: " + e.getMessage());
+                    chatRoomView.pressEnter();
+                    readLine();
+                    continue;
+                }
+                enterRoom(user, selected);
+                // 입장 후 복귀 시 목록 새로고침
+                rooms = chatRoomService.listPopularOpenRooms(OPEN_CHAT_LIMIT);
+                header = "오픈 채팅 — 인기";
+            } catch (NumberFormatException ignored) {}
+        }
+    }
+
+    private static String promptSearchKeyword() {
+        mainView.clearScreen();
+        chatRoomView.printOpenRoomSearchPrompt();
+        return readLine();
+    }
+
+    private static ChatRoom createOpenChat(Users user) {
+        mainView.clearScreen();
+        chatRoomView.printOpenRoomCreateForm();
+        String name = readLine();
+        if (name == null || name.isBlank()) return null;
+
+        chatRoomView.printOpenRoomDescriptionPrompt();
+        String description = readLine();
+
+        chatRoomView.printOpenRoomCreateConfirm(name.trim(), description);
+        String confirm = readLine();
+        if (!"y".equalsIgnoreCase(confirm)) return null;
+
+        try {
+            ChatRoom room = chatRoomService.createRoom(name.trim(), "OPEN", null, description, user.getUserId());
+            chatRoomView.printCreateSuccess(room);
+            chatRoomView.pressEnter();
+            readLine();
+            return room;
+        } catch (IllegalArgumentException e) {
+            chatRoomView.printCreateFail(e.getMessage());
+            chatRoomView.pressEnter();
+            readLine();
+            return null;
         }
     }
 
@@ -284,15 +390,17 @@ public class GitalkApplication {
         return true;
     }
 
-    private static ChatRoom createRoom(Users user) {
+    private static ChatRoom createTeamRoom(Users user) {
         mainView.clearScreen();
-        chatRoomView.printCreateForm();
+        chatRoomView.printTeamCreateForm();
         String name = readLine();
         if (name == null || name.isBlank()) return null;
 
         try {
-            ChatRoom room = chatRoomService.createRoom(name.trim(), "OPEN", null, user.getUserId());
+            ChatRoom room = chatRoomService.createRoom(name.trim(), "TEAM", null, null, user.getUserId());
             chatRoomView.printCreateSuccess(room);
+            chatRoomView.pressEnter();
+            readLine();
             return room;
         } catch (IllegalArgumentException e) {
             chatRoomView.printCreateFail(e.getMessage());

--- a/src/main/java/com/gitalk/common/util/Layout.java
+++ b/src/main/java/com/gitalk/common/util/Layout.java
@@ -39,6 +39,9 @@ public final class Layout {
      * 정확히 width 컬럼이 되도록 맞춘다.
      * - 짧으면 우측에 공백 패딩
      * - 길면 끝을 ellipsis(…) 로 잘라 width 컬럼에 맞춤
+     *
+     * truncate 가 한글 등 2-컬럼 문자 경계 때문에 width 보다 1 작은 결과를 낼 수 있어,
+     * 마지막에 한 번 더 우측 패딩으로 정확히 width 컬럼을 보장한다.
      */
     public static String fit(String s, int width) {
         if (width <= 0) return "";
@@ -46,7 +49,9 @@ public final class Layout {
         int w = displayWidth(text);
         if (w == width) return text;
         if (w <  width) return text + " ".repeat(width - w);
-        return truncate(text, width);
+        String truncated = truncate(text, width);
+        int tw = displayWidth(truncated);
+        return tw < width ? truncated + " ".repeat(width - tw) : truncated;
     }
 
     /** 좌측 공백으로 width 컬럼까지 패딩 (숫자·뱃지 우측 정렬용) */

--- a/src/main/java/com/gitalk/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/gitalk/domain/chat/domain/ChatRoom.java
@@ -8,27 +8,30 @@ public class ChatRoom {
     private String name;
     private String type;       // TEAM / OPEN
     private String teamUrl;
+    private String description;       // OPEN 방 토픽 설명 (TEAM은 보통 null)
     private Long creatorId;
     private String creatorNickname;  // 조회 시 JOIN으로 채움
     private LocalDateTime createdAt;
 
     // DB 조회용 (전체 필드)
-    public ChatRoom(Long roomId, String name, String type, String teamUrl,
+    public ChatRoom(Long roomId, String name, String type, String teamUrl, String description,
                     Long creatorId, String creatorNickname, LocalDateTime createdAt) {
         this.roomId = roomId;
         this.name = name;
         this.type = type;
         this.teamUrl = teamUrl;
+        this.description = description;
         this.creatorId = creatorId;
         this.creatorNickname = creatorNickname;
         this.createdAt = createdAt;
     }
 
     // 신규 생성용 (roomId, createdAt 은 DB 자동 생성)
-    public ChatRoom(String name, String type, String teamUrl, Long creatorId) {
+    public ChatRoom(String name, String type, String teamUrl, String description, Long creatorId) {
         this.name = name;
         this.type = type;
         this.teamUrl = teamUrl;
+        this.description = description;
         this.creatorId = creatorId;
     }
 
@@ -36,7 +39,12 @@ public class ChatRoom {
     public String getName()             { return name; }
     public String getType()             { return type; }
     public String getTeamUrl()          { return teamUrl; }
+    public String getDescription()      { return description; }
     public Long getCreatorId()          { return creatorId; }
     public String getCreatorNickname()  { return creatorNickname; }
     public LocalDateTime getCreatedAt() { return createdAt; }
+
+    public boolean isOpen() {
+        return "OPEN".equals(type);
+    }
 }

--- a/src/main/java/com/gitalk/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gitalk/domain/chat/repository/ChatRoomRepository.java
@@ -12,4 +12,10 @@ public interface ChatRoomRepository {
     List<ChatRoom> findByType(String type);
     boolean existsByTypeAndName(String type, String name);
     void deleteById(Long roomId);
+
+    /** 멤버수 desc 로 정렬한 OPEN 방 인기 목록 */
+    List<ChatRoom> findPopularOpenRooms(int limit);
+
+    /** 이름 부분 일치(대소문자 무시) 검색, OPEN 방 한정 */
+    List<ChatRoom> searchOpenRoomsByName(String keyword, int limit);
 }

--- a/src/main/java/com/gitalk/domain/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/gitalk/domain/chat/repository/ChatRoomRepositoryImpl.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public class ChatRoomRepositoryImpl implements ChatRoomRepository {
 
     private static final String SELECT_BASE = """
-            SELECT r.roomid, r.name, r.type, r.team_url, r.creator_id, r.created_at,
+            SELECT r.roomid, r.name, r.type, r.team_url, r.description, r.creator_id, r.created_at,
                    u.nickname AS creator_nickname
             FROM chat_rooms r
             LEFT JOIN users u ON r.creator_id = u.userid
@@ -19,14 +19,15 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
 
     @Override
     public ChatRoom save(ChatRoom room) {
-        String sql = "INSERT INTO chat_rooms (name, type, team_url, creator_id) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO chat_rooms (name, type, team_url, description, creator_id) VALUES (?, ?, ?, ?, ?)";
         try (Connection conn = DBConnection.makeConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             pstmt.setString(1, room.getName());
             pstmt.setString(2, room.getType());
             pstmt.setString(3, room.getTeamUrl());
-            if (room.getCreatorId() != null) pstmt.setLong(4, room.getCreatorId());
-            else pstmt.setNull(4, java.sql.Types.BIGINT);
+            pstmt.setString(4, room.getDescription());
+            if (room.getCreatorId() != null) pstmt.setLong(5, room.getCreatorId());
+            else pstmt.setNull(5, java.sql.Types.BIGINT);
             pstmt.executeUpdate();
             ResultSet keys = pstmt.getGeneratedKeys();
             if (keys.next()) {
@@ -110,6 +111,58 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
         }
     }
 
+    @Override
+    public List<ChatRoom> findPopularOpenRooms(int limit) {
+        // 멤버수 desc, 동률이면 최신순. LEFT JOIN 으로 멤버 0명 방도 포함.
+        String sql = """
+                SELECT r.roomid, r.name, r.type, r.team_url, r.description, r.creator_id, r.created_at,
+                       u.nickname AS creator_nickname
+                FROM chat_rooms r
+                LEFT JOIN users u ON r.creator_id = u.userid
+                LEFT JOIN chat_room_members m ON m.roomid = r.roomid
+                WHERE r.type = 'OPEN'
+                GROUP BY r.roomid
+                ORDER BY COUNT(m.id) DESC, r.created_at DESC
+                LIMIT ?
+                """;
+        List<ChatRoom> result = new ArrayList<>();
+        try (Connection conn = DBConnection.makeConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, limit);
+            ResultSet rs = pstmt.executeQuery();
+            while (rs.next()) result.add(mapRow(rs));
+        } catch (SQLException e) {
+            throw new RuntimeException("인기 오픈 채팅 조회 실패", e);
+        }
+        return result;
+    }
+
+    @Override
+    public List<ChatRoom> searchOpenRoomsByName(String keyword, int limit) {
+        String sql = """
+                SELECT r.roomid, r.name, r.type, r.team_url, r.description, r.creator_id, r.created_at,
+                       u.nickname AS creator_nickname
+                FROM chat_rooms r
+                LEFT JOIN users u ON r.creator_id = u.userid
+                LEFT JOIN chat_room_members m ON m.roomid = r.roomid
+                WHERE r.type = 'OPEN' AND LOWER(r.name) LIKE ?
+                GROUP BY r.roomid
+                ORDER BY COUNT(m.id) DESC, r.created_at DESC
+                LIMIT ?
+                """;
+        List<ChatRoom> result = new ArrayList<>();
+        try (Connection conn = DBConnection.makeConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, "%" + keyword.toLowerCase() + "%");
+            pstmt.setInt(2, limit);
+            ResultSet rs = pstmt.executeQuery();
+            while (rs.next()) result.add(mapRow(rs));
+        } catch (SQLException e) {
+            throw new RuntimeException("오픈 채팅 검색 실패", e);
+        }
+        return result;
+    }
+
     private ChatRoom mapRow(ResultSet rs) throws SQLException {
         Timestamp ts = rs.getTimestamp("created_at");
         long creatorIdRaw = rs.getLong("creator_id");
@@ -119,6 +172,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
                 rs.getString("name"),
                 rs.getString("type"),
                 rs.getString("team_url"),
+                rs.getString("description"),
                 creatorId,
                 rs.getString("creator_nickname"),
                 ts != null ? ts.toLocalDateTime() : null

--- a/src/main/java/com/gitalk/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/gitalk/domain/chat/service/ChatRoomService.java
@@ -5,8 +5,15 @@ import com.gitalk.domain.chat.repository.ChatRoomMemberRepository;
 import com.gitalk.domain.chat.repository.ChatRoomRepository;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 public class ChatRoomService {
+
+    /** OPEN 방 이름 규칙: 한글/영문/숫자/대시/언더스코어/공백, 3~30자 */
+    private static final Pattern OPEN_ROOM_NAME_PATTERN =
+            Pattern.compile("^[가-힣A-Za-z0-9_\\- ]{3,30}$");
+    private static final int MAX_DESCRIPTION_LENGTH = 500;
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMemberRepository memberRepository;
@@ -24,21 +31,31 @@ public class ChatRoomService {
                 .toList();
     }
 
-    /** 방 생성 후 생성자를 자동으로 멤버에 추가 */
-    public ChatRoom createRoom(String name, String type, String teamUrl, Long creatorId) {
+    public Optional<ChatRoom> getRoom(Long roomId) {
+        return chatRoomRepository.findById(roomId);
+    }
+
+    /** 방 생성 후 생성자를 자동으로 멤버에 추가. OPEN 방은 정규식 검증, TEAM 방은 길이만 검사. */
+    public ChatRoom createRoom(String name, String type, String teamUrl, String description, Long creatorId) {
         String trimmed = name == null ? "" : name.trim();
         if (trimmed.isBlank()) {
             throw new IllegalArgumentException("방 이름을 입력해주세요.");
         }
-        if (trimmed.length() > 30) {
+        if ("OPEN".equals(type)) {
+            validateOpenRoomName(trimmed);
+            if (chatRoomRepository.existsByTypeAndName("OPEN", trimmed)) {
+                throw new IllegalArgumentException("이미 같은 이름의 오픈채팅방이 있습니다.");
+            }
+        } else if (trimmed.length() > 30) {
             throw new IllegalArgumentException("방 이름은 30자 이하여야 합니다.");
         }
-        // OPEN 타입은 전역 유니크. TEAM 은 자유.
-        if ("OPEN".equals(type) && chatRoomRepository.existsByTypeAndName("OPEN", trimmed)) {
-            throw new IllegalArgumentException("이미 같은 이름의 오픈채팅방이 있습니다.");
+        String desc = description == null ? null : description.trim();
+        if (desc != null && desc.isEmpty()) desc = null;
+        if (desc != null && desc.length() > MAX_DESCRIPTION_LENGTH) {
+            throw new IllegalArgumentException("설명은 " + MAX_DESCRIPTION_LENGTH + "자 이하여야 합니다.");
         }
         try {
-            ChatRoom room = chatRoomRepository.save(new ChatRoom(trimmed, type, teamUrl, creatorId));
+            ChatRoom room = chatRoomRepository.save(new ChatRoom(trimmed, type, teamUrl, desc, creatorId));
             memberRepository.addMember(room.getRoomId(), creatorId);
             return room;
         } catch (RuntimeException e) {
@@ -48,6 +65,35 @@ public class ChatRoomService {
             }
             throw e;
         }
+    }
+
+    /** OPEN 방 이름 정규식 검증 */
+    public void validateOpenRoomName(String name) {
+        if (name == null || !OPEN_ROOM_NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException(
+                    "오픈 채팅 이름은 한글/영문/숫자/대시(-)/언더스코어(_)/공백 3~30자만 가능합니다.");
+        }
+    }
+
+    /** 인기 오픈 채팅 목록 (멤버수 desc) */
+    public List<ChatRoom> listPopularOpenRooms(int limit) {
+        return chatRoomRepository.findPopularOpenRooms(limit);
+    }
+
+    /** 이름 부분 일치 검색 */
+    public List<ChatRoom> searchOpenRooms(String keyword, int limit) {
+        if (keyword == null || keyword.isBlank()) return List.of();
+        return chatRoomRepository.searchOpenRoomsByName(keyword.trim(), limit);
+    }
+
+    /** 오픈 채팅 자유 입장: 이미 멤버여도 무해 (UNIQUE 인덱스로 INSERT IGNORE 효과) */
+    public void joinOpenRoom(Long roomId, Long userId) {
+        ChatRoom room = chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 채팅방입니다."));
+        if (!room.isOpen()) {
+            throw new RuntimeException("오픈 채팅방이 아닙니다.");
+        }
+        memberRepository.addMember(roomId, userId);
     }
 
     public void joinRoom(Long roomId, Long userId) {

--- a/src/main/java/com/gitalk/domain/chat/session/ChatRoomSession.java
+++ b/src/main/java/com/gitalk/domain/chat/session/ChatRoomSession.java
@@ -98,6 +98,7 @@ public class ChatRoomSession {
     private Long currentRoomId;
     private Long currentUserId;
     private String currentNickname;
+    private String currentRoomType;   // "TEAM" 또는 "OPEN" — 명령 권한 분기용
 
     // 이미지(ASCII 아트) 수신 저장소 — 세션 동안 유지
     private final Map<String, String> asciiArtStore = new ConcurrentHashMap<>();
@@ -133,6 +134,9 @@ public class ChatRoomSession {
         currentUserId = userId;
         currentRoomId = roomId;
         currentNickname = nickname;
+        currentRoomType = chatRoomService.getRoom(roomId)
+                .map(r -> r.getType())
+                .orElse("TEAM");
         asciiArtStore.clear();
         imageCounter.set(0);
 
@@ -226,9 +230,12 @@ public class ChatRoomSession {
             currentRoomId = null;
             currentUserId = null;
             currentNickname = null;
+            currentRoomType = null;
             Spinner.setSuppressed(false);
         }
     }
+
+    // ── 외부 명령 (방 밖에서 /search 등) ─────────────────────────────────
 
     public void handleOutsideRoomCommand(Long userId, String nickname, String rawCommand) {
         String command = sanitize(rawCommand);
@@ -286,6 +293,22 @@ public class ChatRoomSession {
             lineReader = previousLineReader;
             terminal = previousTerminal;
         }
+    }
+
+    // ── 방 타입 헬퍼 (OPEN 채팅 권한 분기) ──────────────────────────────
+
+    /** 현재 입장 중인 방이 OPEN 채팅인지 */
+    private boolean isOpenChatRoom() {
+        return "OPEN".equals(currentRoomType);
+    }
+
+    /** OPEN 방에서 호출 시 안내 메시지 출력 후 true 반환 */
+    private boolean blockIfOpenRoom(String commandLabel) {
+        if (isOpenChatRoom()) {
+            printToScroll(DIM + " 오픈 채팅에서는 " + commandLabel + " 기능을 사용할 수 없습니다." + RESET);
+            return true;
+        }
+        return false;
     }
 
     // ── 출력 (JLine printAbove 위임) ────────────────────────────────────────
@@ -648,6 +671,7 @@ public class ChatRoomSession {
     }
 
     private void cmdWebhook(String sub) {
+        if (blockIfOpenRoom("웹훅")) return;
         switch (sub.toLowerCase()) {
             case "start" -> {
                 if (webhookService.isRunning()) {
@@ -684,6 +708,8 @@ public class ChatRoomSession {
     }
 
     private void cmdInvite(String email) {
+        // 오픈 채팅은 자유 입장이라 초대 개념이 없음
+        if (blockIfOpenRoom("초대")) return;
         if (email.isBlank()) {
             printToScroll(DIM + " 사용법: /invite <이메일>" + RESET);
             return;
@@ -703,6 +729,7 @@ public class ChatRoomSession {
     }
 
     private void cmdNotice(String arg) {
+        if (blockIfOpenRoom("공지")) return;
         if (arg.isBlank()) {
             // 공지 목록
             List<Notice> notices = noticeService.getNotices(currentRoomId);
@@ -807,15 +834,17 @@ public class ChatRoomSession {
     }
 
     private void cmdHelp() {
-        printToScroll(BOLD + " ─── 명령어 ───" + RESET);
-        printToScroll(" /notice             공지 목록 보기");
-        printToScroll(" /notice <제목>      공지 등록");
-        printToScroll(" /invite <이메일>    멤버 초대");
+        boolean open = isOpenChatRoom();
+        String teamOnly = open ? DIM + " (팀 전용)" + RESET : "";
+        printToScroll(BOLD + " ─── 명령어 " + (open ? "(오픈 채팅)" : "(팀 채팅)") + " ───" + RESET);
+        printToScroll(" /notice             공지 목록 보기" + teamOnly);
+        printToScroll(" /notice <제목>      공지 등록" + teamOnly);
+        printToScroll(" /invite <이메일>    멤버 초대" + teamOnly);
         printToScroll(" /trend [언어]       GitHub 트렌딩 조회  (예: /trend python)");
         printToScroll(" /news               Hacker News Top 5");
-        printToScroll(" /webhook start      웹훅 서버 시작");
-        printToScroll(" /webhook stop       웹훅 서버 중지");
-        printToScroll(" /webhook list       웹훅 이벤트 목록");
+        printToScroll(" /webhook start      웹훅 서버 시작" + teamOnly);
+        printToScroll(" /webhook stop       웹훅 서버 중지" + teamOnly);
+        printToScroll(" /webhook list       웹훅 이벤트 목록" + teamOnly);
         printToScroll(" /image              이미지 업로드 → ASCII 아트 변환 후 방에 공유");
         printToScroll(" /image <N>.view     수신한 N번 이미지 ASCII 아트 보기");
         printToScroll(" /search <키워드>    현재 방 메시지 검색");

--- a/src/main/java/com/gitalk/domain/chat/view/ChatRoomView.java
+++ b/src/main/java/com/gitalk/domain/chat/view/ChatRoomView.java
@@ -18,7 +18,6 @@ public class ChatRoomView {
 
     // ── 채팅방 목록 컬럼 폭 (표시 너비 기준) ─────────────────────────────────
     private static final int W_INDEX   = 3;   // " 1." ~ "99."
-    private static final int W_TYPE    = 6;   // "[오픈]" 또는 "[팀]"
     private static final int W_NAME    = 22;  // 방 이름 (초과 시 …)
     private static final int W_CREATOR = 10;  // 만든이 닉네임
     private static final int W_DATE    = 8;   // yy/MM/dd
@@ -40,32 +39,139 @@ public class ChatRoomView {
 
     // ── 채팅방 목록 ──────────────────────────────────────────────────────────
 
+    /**
+     * 내 채팅방 목록 — TEAM/OPEN 섹션으로 분리해서 출력.
+     * rooms 리스트는 controller 에서 TEAM 먼저, OPEN 나중으로 정렬되어 있다고 가정.
+     * 번호는 섹션을 가로질러 1..N 으로 연속 부여 (사용자가 단일 숫자로 선택할 수 있도록).
+     */
     public void printRoomList(List<ChatRoom> rooms, Map<Long, Integer> memberCounts) {
         System.out.println("\n" + DIV);
         System.out.println(centerLine("내 채팅방"));
         System.out.println(DIV);
+
         if (rooms.isEmpty()) {
             System.out.println(centerLine("참여 중인 채팅방이 없습니다."));
-            System.out.println(centerLine("방을 만들거나 초대를 받아 참여하세요."));
+            System.out.println(centerLine("[C] 팀 방 만들기 또는 [O] 오픈 채팅에서 둘러보기"));
         } else {
+            // 컬럼 헤더 (회색 한 줄)
+            printRoomListHeader();
+
+            String currentType = null;
             for (int i = 0; i < rooms.size(); i++) {
                 ChatRoom r = rooms.get(i);
-                String idx     = Layout.padLeft((i + 1) + ".", W_INDEX);
-                String typeTag = Layout.fit("TEAM".equals(r.getType()) ? "[팀]" : "[오픈]", W_TYPE);
-                String name    = Layout.fit(r.getName(), W_NAME);
-                String creator = Layout.fit(r.getCreatorNickname() != null ? r.getCreatorNickname() : "?", W_CREATOR);
-                String date    = Layout.fit(r.getCreatedAt() != null ? r.getCreatedAt().format(DATE_FMT) : "", W_DATE);
-                int memberNum  = memberCounts == null ? 0 : memberCounts.getOrDefault(r.getRoomId(), 0);
-                String count   = Layout.padLeft(memberNum + "명", W_COUNT);
-                System.out.println(" " + idx + " " + typeTag + " " + name
-                        + "  " + creator + "  " + date + "  " + count);
+                if (!r.getType().equals(currentType)) {
+                    currentType = r.getType();
+                    String label = "TEAM".equals(currentType) ? "팀 채팅" : "오픈 채팅";
+                    System.out.println(" ─── " + label + " ───");
+                }
+                printRoomListRow(i + 1, r, memberCounts);
             }
         }
+
         System.out.println(DIV);
-        System.out.println(centerLine("C. 방 만들기    0. 취소"));
+        System.out.println(centerLine("C. 팀 방 만들기    O. 오픈 채팅 둘러보기    0. 취소"));
         System.out.println(DIV);
         System.out.print(" 선택 > ");
         System.out.flush();
+    }
+
+    private void printRoomListHeader() {
+        String idx     = Layout.padLeft("#", W_INDEX);
+        String name    = Layout.fit("이름", W_NAME);
+        String creator = Layout.fit("만든이", W_CREATOR);
+        String date    = Layout.fit("날짜", W_DATE);
+        String count   = Layout.padLeft("인원", W_COUNT);
+        System.out.println(" " + idx + " " + name
+                + "  " + creator + "  " + date + "  " + count);
+    }
+
+    private void printRoomListRow(int index, ChatRoom r, Map<Long, Integer> memberCounts) {
+        String idx     = Layout.padLeft(index + ".", W_INDEX);
+        String name    = Layout.fit(r.getName(), W_NAME);
+        String creator = Layout.fit(r.getCreatorNickname() != null ? r.getCreatorNickname() : "?", W_CREATOR);
+        String date    = Layout.fit(r.getCreatedAt() != null ? r.getCreatedAt().format(DATE_FMT) : "", W_DATE);
+        int memberNum  = memberCounts == null ? 0 : memberCounts.getOrDefault(r.getRoomId(), 0);
+        String count   = Layout.padLeft(memberNum + "명", W_COUNT);
+        System.out.println(" " + idx + " " + name
+                + "  " + creator + "  " + date + "  " + count);
+    }
+
+    // ── 오픈 채팅 ────────────────────────────────────────────────────────────
+
+    private static final int W_OPEN_NAME    = 22;
+    private static final int W_OPEN_COUNT   = 5;   // "999명"
+    private static final int W_OPEN_DESC    = 30;  // 토픽 설명
+
+    public void printOpenRoomList(String header, List<ChatRoom> rooms, Map<Long, Integer> memberCounts) {
+        System.out.println("\n" + DIV);
+        System.out.println(centerLine(header));
+        System.out.println(DIV);
+        if (rooms == null || rooms.isEmpty()) {
+            System.out.println(centerLine("표시할 오픈 채팅이 없습니다."));
+            System.out.println(centerLine("[C] 키로 새 오픈 방을 만들어 보세요."));
+        } else {
+            printOpenRoomListHeader();
+            for (int i = 0; i < rooms.size(); i++) {
+                printOpenRoomListRow(i + 1, rooms.get(i), memberCounts);
+            }
+        }
+        System.out.println(DIV);
+        System.out.println(centerLine("C. 새 오픈 방 만들기    S. 검색    0. 뒤로"));
+        System.out.println(DIV);
+        System.out.print(" 선택 > ");
+        System.out.flush();
+    }
+
+    private void printOpenRoomListHeader() {
+        String idx   = Layout.padLeft("#", W_INDEX);
+        String name  = Layout.fit("이름", W_OPEN_NAME);
+        String count = Layout.padLeft("인원", W_OPEN_COUNT);
+        String desc  = Layout.fit("설명", W_OPEN_DESC);
+        System.out.println(" " + idx + " " + name + "  " + count + "  " + desc);
+    }
+
+    private void printOpenRoomListRow(int index, ChatRoom r, Map<Long, Integer> memberCounts) {
+        String idx   = Layout.padLeft(index + ".", W_INDEX);
+        String name  = Layout.fit(r.getName(), W_OPEN_NAME);
+        int memberN  = memberCounts == null ? 0 : memberCounts.getOrDefault(r.getRoomId(), 0);
+        String count = Layout.padLeft(memberN + "명", W_OPEN_COUNT);
+        String desc  = Layout.fit(r.getDescription() != null ? r.getDescription() : "", W_OPEN_DESC);
+        System.out.println(" " + idx + " " + name + "  " + count + "  " + desc);
+    }
+
+    public void printOpenRoomSearchPrompt() {
+        System.out.println("\n" + DIV);
+        System.out.println(centerLine("오픈 채팅 검색"));
+        System.out.println(DIV);
+        System.out.print(" 검색어 (취소: 빈값) > ");
+        System.out.flush();
+    }
+
+    public void printOpenRoomCreateForm() {
+        System.out.println("\n" + DIV);
+        System.out.println(centerLine("새 오픈 채팅 만들기"));
+        System.out.println(DIV);
+        System.out.println(centerLine("이름 규칙: 한글/영문/숫자/대시(-)/언더스코어(_)/공백, 3~30자"));
+        System.out.println(DIV);
+        System.out.print(" 이름 > ");
+        System.out.flush();
+    }
+
+    public void printOpenRoomDescriptionPrompt() {
+        System.out.print(" 설명 (선택, Enter로 건너뛰기) > ");
+        System.out.flush();
+    }
+
+    public void printOpenRoomCreateConfirm(String name, String description) {
+        System.out.println();
+        System.out.println(" 이름 : " + name);
+        System.out.println(" 설명 : " + (description == null || description.isBlank() ? "(없음)" : description));
+        System.out.print(" 생성하시겠습니까? (y/n) > ");
+        System.out.flush();
+    }
+
+    public void printOpenRoomNoResult(String keyword) {
+        System.out.println(" '" + keyword + "' 에 해당하는 오픈 채팅이 없습니다.");
     }
 
     // ── 방 액션 메뉴 (최신 공지 포함) ───────────────────────────────────────
@@ -142,10 +248,16 @@ public class ChatRoomView {
     // ── 방 만들기 ────────────────────────────────────────────────────────────
 
     public void printCreateForm() {
+        printTeamCreateForm();
+    }
+
+    public void printTeamCreateForm() {
         System.out.println("\n" + DIV);
-        System.out.println(centerLine("채팅방 만들기"));
+        System.out.println(centerLine("새 팀 채팅방 만들기"));
         System.out.println(DIV);
-        System.out.print(" 방 이름 > ");
+        System.out.println(centerLine("팀원을 초대해서 사용하는 비공개 방입니다."));
+        System.out.println(DIV);
+        System.out.print(" 방 이름 (1~30자) > ");
         System.out.flush();
     }
 


### PR DESCRIPTION
## 관련 이슈
- closes #27

## 작업 내용
토픽 기반 공개 채팅 방(OPEN)을 도입하고, 내 방 화면을 TEAM/OPEN 섹션으로 분리해서 정해진 컬럼 레이아웃으로 표시합니다. 같은 시점에 dev에 머지된 채팅 검색 기능(#28)과 충돌 해결까지 포함합니다.

## 변경 사항
- [x] 기능 구현
- [x] 기능 수정
- [ ] 문서 작업
- [ ] 테스트

## 구현 내용 상세

### 1. 오픈 채팅 (토픽 기반 공개 방)
- `chat_rooms` 에 `description VARCHAR(500)` 컬럼 추가 (init.sql + 컨테이너 ALTER)
- `ChatRoom` 도메인에 `description` 필드 + `isOpen()` 헬퍼
- `ChatRoomRepository`:
  - `findPopularOpenRooms(limit)` — `LEFT JOIN chat_room_members GROUP BY ORDER BY COUNT DESC, created_at DESC` (멤버수 인기 정렬, 동률 시 최신순)
  - `searchOpenRoomsByName(keyword, limit)` — 대소문자 무시 부분 일치
- `ChatRoomService`:
  - `createRoom(name, type, teamUrl, description, creatorId)` — description 인자 추가
  - `validateOpenRoomName` 정규식 `^[가-힣A-Za-z0-9_\\- ]{3,30}$` (한글/영문/숫자/대시/언더스코어/공백, 3~30자)
  - `listPopularOpenRooms`, `searchOpenRooms`, `joinOpenRoom` (자유 입장)
  - `getRoom(roomId)` 단건 조회 (Optional)
- `GitalkApplication`:
  - `runChatRoom`: TEAM 먼저 OPEN 나중 정렬 → view에 전달
  - `[c]` → `createTeamRoom` (TEAM 하드코딩, 단순 이름 입력)
  - `[o]` → `runOpenChat` 분기 (인기 목록 / 번호 선택 자동 가입 / `[c]` 만들기 / `[s]` 검색)
  - `createOpenChat`: 이름 + 설명 입력, 정규식 검증, 중복 검사

### 2. 채팅방 목록 레이아웃 정비
- `printRoomList`: TEAM/OPEN 섹션 분리 + 컬럼 헤더 (`# / 이름 / 만든이 / 날짜 / 인원`) + 통합 번호 (섹션을 가로질러 1..N)
- `printOpenRoomList`: 컬럼 헤더 (`# / 이름 / 인원 / 설명`) 추가
- `printRoomListHeader/Row`, `printOpenRoomListHeader/Row` 헬퍼로 정렬 일관성
- `Layout.fit` 버그 수정: truncate 결과가 한글 2-col 경계 때문에 `width-1` col만 채우는 경우 우측 패딩 보정 → 긴 한글 이름 행이 다른 행과 어긋나던 '흔들림' 해결

### 3. OPEN 방 권한 분기 (ChatRoomSession)
- `enter()` 진입 시 `currentRoomType` 캐시 (DB 1회 조회)
- `isOpenChatRoom()` / `blockIfOpenRoom(label)` 헬퍼
- `/invite`, `/notice`, `/webhook` 각 시작에서 차단 + 안내 메시지
- `/help` 출력에 OPEN 방이면 `(팀 전용)` 마킹

### 4. dev (#28) 채팅 검색과의 통합
- origin/dev (검색 기능 + Mongo 기반 메시지 저장 구조) 위에 rebase
- `ChatRoomSession` 에서 검색용 `handleOutsideRoomCommand` / `runOutsideRoomCommandWithViewer` 와 OPEN 권한 헬퍼가 같은 위치에서 충돌 → 양쪽 모두 보존하도록 머지
- `lib/` 에 mongodb-driver-sync 5.2.0, mongodb-driver-core 5.2.0, bson 5.2.0 jar 추가

## Test plan
- [ ] `bash compile.sh` 성공
- [ ] `docker compose up -d` 후 `mongodb-container` 정상 기동
- [ ] `bash run.sh server` (소켓 6000 + HTTP 6001 + Mongo 연결)
- [ ] `bash run.sh` → 로그인 → 1.채팅방
  - [ ] `[c]` → 팀 방 만들기 (예: `team-A`) → 입장
  - [ ] 방 목록에 "팀 채팅" 섹션 표시
  - [ ] `[o]` → 오픈 채팅 둘러보기 → `[c]` → 새 오픈 방 (예: `python-talk` / `스프링 공부`)
  - [ ] 한글 이름 통과, 정규식 위반(예: `ab`) 거부
  - [ ] `[s]` → 검색 → 결과 자동 가입 → 입장
  - [ ] 내 방 목록에 TEAM/OPEN 섹션 분리되어 표시되고 번호가 연속
- [ ] OPEN 방 안에서 `/invite`, `/notice`, `/webhook` 차단 메시지 확인
- [ ] OPEN 방에서 `/trend`, `/news`, `/image`, `/search`, 챗봇 정상 동작
- [ ] 긴 한글 이름이 잘려도 다른 행과 정확히 정렬 확인

## 의존성
- #25 (멀티룸 인프라) 머지 완료
- #28 (채팅 검색 / Mongo) 머지 완료 — rebase 로 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)